### PR TITLE
Add documentation update guidelines and mark Phase 2 complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,13 @@ All features must have corresponding tests written BEFORE implementation.
 - **Release**: Automated npm releases with semantic versioning
 - **Distribution**: Package available via `npx` command
 
+### Documentation Updates
+When completing work on a phase or major feature (according to the todo list):
+1. **CLAUDE.md**: Update the "Development Status" section to mark completed phases and list achievements
+2. **README.md**: Update the "Development Plan" section to mark completed phase items with `[x]`
+
+Both documentation files must be kept in sync to reflect the current project status. This ensures consistency across project documentation and helps track progress accurately.
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ This project follows **Test-Driven Development (TDD)** principles:
 - [x] Set up GitHub Actions CI/CD
 
 ### Phase 2: Schema Integration
-- [ ] Create schema loader utility
-- [ ] Implement caching mechanism for schema data
-- [ ] Build indexing system for fast tag lookups
-- [ ] Create type definitions for schema structures
+- [x] Create schema loader utility
+- [x] Implement caching mechanism for schema data
+- [x] Build indexing system for fast tag lookups
+- [x] Create type definitions for schema structures
 
 ### Phase 3: Core Tool Implementation
 


### PR DESCRIPTION
Added new section in CLAUDE.md "Documentation Updates" that specifies:
- When completing work on phases/features, both CLAUDE.md and README.md must be updated to reflect completion status
- CLAUDE.md: Update "Development Status" section
- README.md: Mark completed phase items with [x]

Also updated README.md to mark all Phase 2 tasks as completed:
- [x] Create schema loader utility
- [x] Implement caching mechanism for schema data
- [x] Build indexing system for fast tag lookups
- [x] Create type definitions for schema structures

This ensures documentation consistency and accurate progress tracking.