### PR TITLE
Add quick setup instruction with claude mcp add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,19 @@ npm start
 
 ### Configuration
 
-Add to your MCP client configuration:
+#### Quick Setup with Claude Code CLI
+
+The easiest way to add this MCP server to Claude Code CLI is using the built-in command:
+
+```bash
+claude mcp add @gander-tools/osm-tagging-schema-mcp
+```
+
+This will automatically configure the server in your Claude Code CLI environment.
+
+#### Manual Configuration
+
+Alternatively, you can manually add to your MCP client configuration:
 
 ```json
 {
@@ -196,6 +208,11 @@ Add to your MCP client configuration:
   }
 }
 ```
+
+**Configuration file locations:**
+- **Claude Code CLI:** `~/.config/claude-code/config.json`
+- **Claude Desktop (macOS):** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Claude Desktop (Windows):** `%APPDATA%\Claude\claude_desktop_config.json`
 
 ### Development
 


### PR DESCRIPTION
- Add Quick Setup section with claude mcp add command for easy installation
- Reorganize Configuration section with Quick Setup and Manual Configuration subsections
- Add configuration file locations for Claude Code CLI and Claude Desktop
- Provide clear paths for different platforms (macOS, Windows, Linux)