### PR TITLE
Implement get_schema_stats tool with TDD approach

### DIFF
--- a/src/tools/schema.ts
+++ b/src/tools/schema.ts
@@ -1,0 +1,28 @@
+import type { SchemaLoader } from "../utils/schema-loader.js";
+
+/**
+ * Schema statistics interface
+ */
+export interface SchemaStats {
+	presetCount: number;
+	fieldCount: number;
+	categoryCount: number;
+	deprecatedCount: number;
+}
+
+/**
+ * Get statistics about the OSM tagging schema
+ *
+ * @param loader - Schema loader instance
+ * @returns Schema statistics including counts of presets, fields, categories, and deprecated items
+ */
+export async function getSchemaStats(loader: SchemaLoader): Promise<SchemaStats> {
+	const schema = await loader.loadSchema();
+
+	return {
+		presetCount: Object.keys(schema.presets).length,
+		fieldCount: Object.keys(schema.fields).length,
+		categoryCount: Object.keys(schema.categories).length,
+		deprecatedCount: schema.deprecated.length,
+	};
+}

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -68,8 +68,29 @@ describe("MCP Server Integration", () => {
 
 			assert.ok(response);
 			assert.ok(Array.isArray(response.tools));
-			// Currently server returns empty tools list
-			assert.strictEqual(response.tools.length, 0);
+			assert.strictEqual(response.tools.length, 1);
+			assert.strictEqual(response.tools[0]?.name, "get_schema_stats");
+		});
+
+		it("should call get_schema_stats tool successfully", async () => {
+			const response = await client.callTool({
+				name: "get_schema_stats",
+				arguments: {},
+			});
+
+			assert.ok(response);
+			assert.ok(response.content);
+			assert.ok(Array.isArray(response.content));
+			assert.strictEqual(response.content.length, 1);
+			assert.strictEqual(response.content[0]?.type, "text");
+
+			// Parse the stats from the response
+			const stats = JSON.parse((response.content[0] as { text: string }).text);
+			assert.ok(typeof stats.presetCount === "number");
+			assert.ok(typeof stats.fieldCount === "number");
+			assert.ok(typeof stats.categoryCount === "number");
+			assert.ok(typeof stats.deprecatedCount === "number");
+			assert.ok(stats.presetCount > 0);
 		});
 
 		it("should throw error for unknown tool", async () => {

--- a/tests/tools/schema.test.ts
+++ b/tests/tools/schema.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { getSchemaStats } from "../../src/tools/schema.ts";
+import { SchemaLoader } from "../../src/utils/schema-loader.ts";
+
+describe("Schema Tools", () => {
+	describe("getSchemaStats", () => {
+		it("should return schema statistics with preset count", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const stats = await getSchemaStats(loader);
+
+			assert.ok(stats, "Stats should be returned");
+			assert.ok(typeof stats.presetCount === "number", "Should have preset count");
+			assert.ok(stats.presetCount > 0, "Preset count should be greater than 0");
+		});
+
+		it("should return schema statistics with field count", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const stats = await getSchemaStats(loader);
+
+			assert.ok(typeof stats.fieldCount === "number", "Should have field count");
+			assert.ok(stats.fieldCount > 0, "Field count should be greater than 0");
+		});
+
+		it("should return schema statistics with category count", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const stats = await getSchemaStats(loader);
+
+			assert.ok(typeof stats.categoryCount === "number", "Should have category count");
+			assert.ok(stats.categoryCount > 0, "Category count should be greater than 0");
+		});
+
+		it("should return schema statistics with deprecated tag count", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const stats = await getSchemaStats(loader);
+
+			assert.ok(
+				typeof stats.deprecatedCount === "number",
+				"Should have deprecated count",
+			);
+			assert.ok(
+				stats.deprecatedCount >= 0,
+				"Deprecated count should be non-negative",
+			);
+		});
+
+		it("should use cached data on subsequent calls", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+
+			const stats1 = await getSchemaStats(loader);
+			const stats2 = await getSchemaStats(loader);
+
+			assert.deepStrictEqual(stats1, stats2, "Stats should be identical from cache");
+		});
+	});
+});


### PR DESCRIPTION
Test Phase (Red):
- Create tests/tools/schema.test.ts with 5 unit tests
- Tests initially fail (module doesn't exist)

Implementation Phase (Green):
- Create src/tools/schema.ts with getSchemaStats function
- Implement SchemaStats interface with 4 metrics
- Integrate tool with MCP server in src/index.ts
- Add integration test for tool invocation
- All 25 tests passing (10 suites)

Features:
- Returns preset, field, category, and deprecated item counts
- Leverages existing SchemaLoader with caching
- Modular architecture for reuse by other tools
- Full test coverage (unit + integration)

Tool Registration:
- MCP tool name: get_schema_stats
- No input parameters required
- Returns JSON with schema statistics