### PR TITLE
Implement get_categories tool with TDD approach

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { SchemaLoader } from "./utils/schema-loader.js";
-import { getSchemaStats } from "./tools/schema.js";
+import { getSchemaStats, getCategories } from "./tools/schema.js";
 
 /**
  * Create and configure the MCP server
@@ -37,6 +37,16 @@ export function createServer(): Server {
 					required: [],
 				},
 			},
+			{
+				name: "get_categories",
+				description:
+					"Get all available tag categories with counts of presets in each category, sorted by name",
+				inputSchema: {
+					type: "object",
+					properties: {},
+					required: [],
+				},
+			},
 		],
 	}));
 
@@ -50,6 +60,18 @@ export function createServer(): Server {
 					{
 						type: "text",
 						text: JSON.stringify(stats, null, 2),
+					},
+				],
+			};
+		}
+
+		if (name === "get_categories") {
+			const categories = await getCategories(schemaLoader);
+			return {
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify(categories, null, 2),
 					},
 				],
 			};

--- a/src/tools/schema.ts
+++ b/src/tools/schema.ts
@@ -11,6 +11,14 @@ export interface SchemaStats {
 }
 
 /**
+ * Category information interface
+ */
+export interface CategoryInfo {
+	name: string;
+	count: number;
+}
+
+/**
  * Get statistics about the OSM tagging schema
  *
  * @param loader - Schema loader instance
@@ -25,4 +33,25 @@ export async function getSchemaStats(loader: SchemaLoader): Promise<SchemaStats>
 		categoryCount: Object.keys(schema.categories).length,
 		deprecatedCount: schema.deprecated.length,
 	};
+}
+
+/**
+ * Get all tag categories with counts of presets in each category
+ *
+ * @param loader - Schema loader instance
+ * @returns Array of categories sorted by name, each with name and preset count
+ */
+export async function getCategories(loader: SchemaLoader): Promise<CategoryInfo[]> {
+	const schema = await loader.loadSchema();
+
+	// Create array of categories with counts
+	const categories: CategoryInfo[] = Object.entries(schema.categories).map(
+		([name, category]) => ({
+			name,
+			count: category.members?.length || 0,
+		}),
+	);
+
+	// Sort by name
+	return categories.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -68,8 +68,9 @@ describe("MCP Server Integration", () => {
 
 			assert.ok(response);
 			assert.ok(Array.isArray(response.tools));
-			assert.strictEqual(response.tools.length, 1);
+			assert.strictEqual(response.tools.length, 2);
 			assert.strictEqual(response.tools[0]?.name, "get_schema_stats");
+			assert.strictEqual(response.tools[1]?.name, "get_categories");
 		});
 
 		it("should call get_schema_stats tool successfully", async () => {
@@ -91,6 +92,26 @@ describe("MCP Server Integration", () => {
 			assert.ok(typeof stats.categoryCount === "number");
 			assert.ok(typeof stats.deprecatedCount === "number");
 			assert.ok(stats.presetCount > 0);
+		});
+
+		it("should call get_categories tool successfully", async () => {
+			const response = await client.callTool({
+				name: "get_categories",
+				arguments: {},
+			});
+
+			assert.ok(response);
+			assert.ok(response.content);
+			assert.ok(Array.isArray(response.content));
+			assert.strictEqual(response.content.length, 1);
+			assert.strictEqual(response.content[0]?.type, "text");
+
+			// Parse the categories from the response
+			const categories = JSON.parse((response.content[0] as { text: string }).text);
+			assert.ok(Array.isArray(categories));
+			assert.ok(categories.length > 0);
+			assert.ok(typeof categories[0].name === "string");
+			assert.ok(typeof categories[0].count === "number");
 		});
 
 		it("should throw error for unknown tool", async () => {

--- a/tests/tools/schema.test.ts
+++ b/tests/tools/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { getSchemaStats } from "../../src/tools/schema.ts";
+import { getSchemaStats, getCategories } from "../../src/tools/schema.ts";
 import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("Schema Tools", () => {
@@ -51,6 +51,54 @@ describe("Schema Tools", () => {
 			const stats2 = await getSchemaStats(loader);
 
 			assert.deepStrictEqual(stats1, stats2, "Stats should be identical from cache");
+		});
+	});
+
+	describe("getCategories", () => {
+		it("should return an array of categories", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const categories = await getCategories(loader);
+
+			assert.ok(Array.isArray(categories), "Should return an array");
+			assert.ok(categories.length > 0, "Should have at least one category");
+		});
+
+		it("should return categories with name and count properties", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const categories = await getCategories(loader);
+
+			const firstCategory = categories[0];
+			assert.ok(firstCategory, "Should have first category");
+			assert.ok(typeof firstCategory.name === "string", "Category should have name");
+			assert.ok(typeof firstCategory.count === "number", "Category should have count");
+			assert.ok(firstCategory.count >= 0, "Count should be non-negative");
+		});
+
+		it("should return categories sorted by name", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const categories = await getCategories(loader);
+
+			for (let i = 1; i < categories.length; i++) {
+				const prev = categories[i - 1];
+				const curr = categories[i];
+				assert.ok(
+					prev && curr && prev.name <= curr.name,
+					`Categories should be sorted: ${prev?.name} <= ${curr?.name}`,
+				);
+			}
+		});
+
+		it("should use cached data on subsequent calls", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+
+			const categories1 = await getCategories(loader);
+			const categories2 = await getCategories(loader);
+
+			assert.deepStrictEqual(
+				categories1,
+				categories2,
+				"Categories should be identical from cache",
+			);
 		});
 	});
 });


### PR DESCRIPTION
Test Phase (Red):
- Create 4 unit tests for getCategories in tests/tools/schema.test.ts
- Tests initially fail (function doesn't exist)

Implementation Phase (Green):
- Implement getCategories function in src/tools/schema.ts
- Create CategoryInfo interface with name and count properties
- Sort categories alphabetically by name
- Count presets in each category using members array
- All 30 tests passing (11 suites)

Integration:
- Add get_categories to MCP server tool list
- Implement handler in CallToolRequestSchema
- Add integration test for tool invocation
- Server now has 2 tools: get_schema_stats, get_categories

Features:
- Returns array of categories with preset counts
- Alphabetically sorted for easy browsing
- Leverages SchemaLoader caching
- Modular architecture for reuse