### PR TITLE
Implement get_tag_values tool with TDD approach (Phase 3.1)

### DIFF
--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -1,0 +1,41 @@
+import type { SchemaLoader } from "../utils/schema-loader.js";
+
+/**
+ * Get all possible values for a given tag key
+ *
+ * @param loader - Schema loader instance
+ * @param tagKey - The tag key to get values for (e.g., "amenity", "building")
+ * @returns Array of unique values for the tag key, sorted alphabetically
+ */
+export async function getTagValues(
+	loader: SchemaLoader,
+	tagKey: string,
+): Promise<string[]> {
+	const schema = await loader.loadSchema();
+
+	// Collect all unique values for the tag key from presets
+	const values = new Set<string>();
+
+	// Iterate through all presets
+	for (const preset of Object.values(schema.presets)) {
+		// Check if this preset has the tag key
+		if (preset.tags[tagKey]) {
+			const value = preset.tags[tagKey];
+			// Skip wildcards and complex patterns
+			if (value && value !== "*" && !value.includes("|")) {
+				values.add(value);
+			}
+		}
+
+		// Also check addTags if present
+		if (preset.addTags?.[tagKey]) {
+			const value = preset.addTags[tagKey];
+			if (value && value !== "*" && !value.includes("|")) {
+				values.add(value);
+			}
+		}
+	}
+
+	// Convert to array and sort
+	return Array.from(values).sort();
+}

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -68,9 +68,10 @@ describe("MCP Server Integration", () => {
 
 			assert.ok(response);
 			assert.ok(Array.isArray(response.tools));
-			assert.strictEqual(response.tools.length, 2);
+			assert.strictEqual(response.tools.length, 3);
 			assert.strictEqual(response.tools[0]?.name, "get_schema_stats");
 			assert.strictEqual(response.tools[1]?.name, "get_categories");
+			assert.strictEqual(response.tools[2]?.name, "get_tag_values");
 		});
 
 		it("should call get_schema_stats tool successfully", async () => {
@@ -112,6 +113,39 @@ describe("MCP Server Integration", () => {
 			assert.ok(categories.length > 0);
 			assert.ok(typeof categories[0].name === "string");
 			assert.ok(typeof categories[0].count === "number");
+		});
+
+		it("should call get_tag_values tool successfully", async () => {
+			const response = await client.callTool({
+				name: "get_tag_values",
+				arguments: { tagKey: "amenity" },
+			});
+
+			assert.ok(response);
+			assert.ok(response.content);
+			assert.ok(Array.isArray(response.content));
+			assert.strictEqual(response.content.length, 1);
+			assert.strictEqual(response.content[0]?.type, "text");
+
+			// Parse the values from the response
+			const values = JSON.parse((response.content[0] as { text: string }).text);
+			assert.ok(Array.isArray(values));
+			assert.ok(values.length > 0);
+			assert.ok(typeof values[0] === "string");
+		});
+
+		it("should throw error for missing tagKey parameter", async () => {
+			await assert.rejects(
+				async () => {
+					await client.callTool({
+						name: "get_tag_values",
+						arguments: {},
+					});
+				},
+				{
+					message: /tagKey parameter is required/,
+				},
+			);
 		});
 
 		it("should throw error for unknown tool", async () => {

--- a/tests/tools/query.test.ts
+++ b/tests/tools/query.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { getTagValues } from "../../src/tools/query.ts";
+import { SchemaLoader } from "../../src/utils/schema-loader.ts";
+
+describe("Tag Query Tools", () => {
+	describe("getTagValues", () => {
+		it("should return values for a valid tag key", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const values = await getTagValues(loader, "amenity");
+
+			assert.ok(Array.isArray(values), "Should return an array");
+			assert.ok(values.length > 0, "Should have at least one value");
+		});
+
+		it("should return unique values only", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const values = await getTagValues(loader, "amenity");
+
+			const uniqueValues = new Set(values);
+			assert.strictEqual(
+				values.length,
+				uniqueValues.size,
+				"Should return unique values only",
+			);
+		});
+
+		it("should return sorted values", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const values = await getTagValues(loader, "amenity");
+
+			const sorted = [...values].sort();
+			assert.deepStrictEqual(values, sorted, "Values should be sorted");
+		});
+
+		it("should return empty array for non-existent tag key", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const values = await getTagValues(loader, "nonexistent_tag_key_12345");
+
+			assert.ok(Array.isArray(values), "Should return an array");
+			assert.strictEqual(values.length, 0, "Should return empty array");
+		});
+
+		it("should use cached data on subsequent calls", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+
+			const values1 = await getTagValues(loader, "amenity");
+			const values2 = await getTagValues(loader, "amenity");
+
+			assert.deepStrictEqual(values1, values2, "Values should be identical from cache");
+		});
+
+		it("should handle tag keys with special characters", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			// Tags like "addr:street" exist in OSM
+			const values = await getTagValues(loader, "building");
+
+			assert.ok(Array.isArray(values), "Should handle tag keys");
+			// Should not throw error
+		});
+	});
+});


### PR DESCRIPTION
Test Phase (Red):
- Create 6 unit tests for getTagValues in tests/tools/query.test.ts
- Tests initially fail (module doesn't exist)

Implementation Phase (Green):
- Create new module src/tools/query.ts for Tag Query Tools
- Implement getTagValues function
- Extract unique values from presets for given tag key
- Filter out wildcards and complex patterns
- Return sorted array of values
- All 38 tests passing (13 suites)

Integration:
- Add get_tag_values to MCP server tool list
- Implement handler with required parameter validation
- Add 2 integration tests (success + missing parameter)
- Server now has 3 tools

Features:
- Required parameter: tagKey (string)
- Returns unique, sorted values for tag key
- Handles non-existent keys (returns empty array)
- Leverages SchemaLoader caching
- Modular architecture in new query.ts module

Phase 3.1 Progress: 1/4 tools complete
- [x] get_tag_values
- [ ] get_tag_values (with descriptions)
- [ ] get_related_tags
- [ ] search_tags
- [ ] get_tag_info