### PR TITLE
Fix: search_tags now searches fields.json for complete coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,7 +348,7 @@ Phase 3 (Core Tool Implementation) is partially completed:
 
 Phase 4 (Testing) has been COMPLETED ✅:
 - ✅ Node.js test runner configured
-- ✅ Unit tests for all implemented tools (89 tests, 27 suites passing)
+- ✅ Unit tests for all implemented tools (90 tests, 28 suites passing)
 - ✅ Integration tests for MCP server (25 tests, 19 suites passing)
   - Modular structure: One integration test file per tool
   - Shared test utilities in `helpers.ts`
@@ -362,6 +362,16 @@ Phase 4 (Testing) has been COMPLETED ✅:
   - Provider pattern for comprehensive data validation
   - 100% coverage: ALL 799 tag keys tested (no hardcoded values)
   - Bidirectional validation ensures complete data integrity
+
+**Bug Fixes**:
+- ✅ **search_tags fields.json coverage** (TDD approach):
+  - **Issue**: search_tags only searched preset.tags and preset.addTags, missing tag keys that exist solely in fields.json (e.g., "wheelchair")
+  - **Root Cause**: Tool ignored fields.json as a data source
+  - **Fix**: Modified search_tags to search fields.json FIRST for matching keys, then presets
+  - **TDD RED**: Added failing test "should find tag keys from fields.json (BUG FIX TEST)" in tests/tools/search-tags.test.ts
+  - **TDD GREEN**: Implemented fix in src/tools/search-tags.ts to query fields.json before presets
+  - **Test Coverage**: Updated both unit and integration tests to validate against fields.json + presets.json
+  - **Result**: search_tags now returns results from both data sources (e.g., wheelchair=yes, wheelchair=limited, wheelchair=no)
 
 **Next Phase: Phase 3 - Continue Core Tool Implementation (Preset & Validation Tools)**
 

--- a/tests/tools/search-tags.test.ts
+++ b/tests/tools/search-tags.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert";
 import { searchTags } from "../../src/tools/search-tags.ts";
 import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
+import fields from "@openstreetmap/id-tagging-schema/dist/fields.json" with { type: "json" };
 
 describe("search_tags", () => {
 	describe("Basic Functionality", () => {
@@ -71,6 +72,31 @@ describe("search_tags", () => {
 				"Results should be identical from cache",
 			);
 		});
+
+		it("should find tag keys from fields.json (BUG FIX TEST)", async () => {
+			const loader = new SchemaLoader({ enableIndexing: true });
+			const results = await searchTags(loader, "wheelchair");
+
+			// wheelchair exists in fields.json with options: yes, limited, no
+			// This test fails before the bug fix
+			assert.ok(results.length > 0, "Should find wheelchair tag from fields.json");
+
+			// Should return results like wheelchair=yes, wheelchair=limited, wheelchair=no
+			const hasWheelchairKey = results.some(r => r.key === "wheelchair");
+			assert.ok(hasWheelchairKey, "Should have results with wheelchair as key");
+
+			// Verify all returned values exist in fields.json options
+			const wheelchairField = fields.wheelchair;
+			assert.ok(wheelchairField, "wheelchair should exist in fields.json");
+
+			const wheelchairResults = results.filter(r => r.key === "wheelchair");
+			for (const result of wheelchairResults) {
+				assert.ok(
+					wheelchairField.options && wheelchairField.options.includes(result.value),
+					`Value "${result.value}" should be in wheelchair field options`,
+				);
+			}
+		});
 	});
 
 	describe("JSON Schema Validation", () => {
@@ -124,30 +150,41 @@ describe("search_tags", () => {
 			}
 		}
 
-		it("should return search results matching JSON preset data", async () => {
+		it("should return search results matching JSON data (presets + fields)", async () => {
 			const loader = new SchemaLoader({ enableIndexing: true });
 			const results = await searchTags(loader, "parking");
 
-			// Verify each result corresponds to actual preset data
+			// Verify each result corresponds to actual JSON data (presets OR fields)
 			for (const result of results) {
 				let found = false;
 
-				for (const preset of Object.values(presets)) {
-					// Check in tags
-					if (preset.tags?.[result.key] === result.value) {
+				// Check in fields.json
+				const field = fields[result.key];
+				if (field?.options && Array.isArray(field.options)) {
+					if (field.options.includes(result.value)) {
 						found = true;
-						break;
 					}
-					// Check in addTags
-					if (preset.addTags?.[result.key] === result.value) {
-						found = true;
-						break;
+				}
+
+				// Check in presets
+				if (!found) {
+					for (const preset of Object.values(presets)) {
+						// Check in tags
+						if (preset.tags?.[result.key] === result.value) {
+							found = true;
+							break;
+						}
+						// Check in addTags
+						if (preset.addTags?.[result.key] === result.value) {
+							found = true;
+							break;
+						}
 					}
 				}
 
 				assert.ok(
 					found,
-					`Result ${result.key}=${result.value} should exist in JSON presets`,
+					`Result ${result.key}=${result.value} should exist in JSON (fields or presets)`,
 				);
 			}
 		});
@@ -160,12 +197,27 @@ describe("search_tags", () => {
 				// Get limited results (default limit: 100)
 				const results = await searchTags(loader, testCase.keyword);
 
-				// Verify all returned results exist in expected set
+				// Verify all returned results exist in JSON (fields OR presets)
 				for (const result of results) {
+					let found = false;
+
+					// Check in fields.json
+					const field = fields[result.key];
+					if (field?.options && Array.isArray(field.options)) {
+						if (field.options.includes(result.value)) {
+							found = true;
+						}
+					}
+
+					// Check in presets (from provider)
 					const tagId = `${result.key}=${result.value}`;
+					if (!found && testCase.expectedTags.has(tagId)) {
+						found = true;
+					}
+
 					assert.ok(
-						testCase.expectedTags.has(tagId),
-						`Search result "${tagId}" for keyword "${testCase.keyword}" should exist in JSON presets`,
+						found,
+						`Search result "${tagId}" for keyword "${testCase.keyword}" should exist in JSON (fields or presets)`,
 					);
 				}
 


### PR DESCRIPTION
Issue: search_tags returned 0 results for "wheelchair" despite it existing in JSON data

Root Cause:
- Tool only searched preset.tags and preset.addTags
- Completely ignored fields.json as a data source
- Tag keys that exist solely in fields.json (like wheelchair) were missed

Solution (TDD RED → GREEN):
1. RED: Added failing test "should find tag keys from fields.json (BUG FIX TEST)"
2. GREEN: Modified search_tags to search fields.json FIRST for matching keys
3. REFACTOR: Updated both unit and integration tests to validate against both data sources

Changes:
- src/tools/search-tags.ts: Query fields.json before presets
- tests/tools/search-tags.test.ts: Added bug fix test + updated validation
- tests/integration/search-tags.test.ts: Updated validation to check fields + presets
- CLAUDE.md: Documented bug fix in Development Status section

Result:
- search_tags now returns results from both fields.json and presets.json
- Example: "wheelchair" now returns wheelchair=yes, wheelchair=limited, wheelchair=no
- All 90 unit tests + 25 integration tests passing