### PR TITLE
Reorganize documentation: Compact README, add ROADMAP and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+#### Phase 3: Core Tool Implementation ✅
+- **Tag Query Tools**:
+  - `get_tag_info` - Get comprehensive information about a tag key
+  - `get_tag_values` - Get all possible values for a tag key
+  - `get_related_tags` - Find tags commonly used together with frequency counts
+  - `search_tags` - Search for tags by keyword in fields and presets
+
+- **Preset Tools**:
+  - `search_presets` - Search presets by keyword or tag with geometry filtering
+  - `get_preset_details` - Get complete preset configuration
+  - `get_preset_tags` - Get recommended tags for a preset
+
+- **Validation Tools**:
+  - `validate_tag` - Validate single tag key-value pairs
+  - `validate_tag_collection` - Validate complete tag collections
+  - `check_deprecated` - Check for deprecated tags with replacement suggestions
+  - `suggest_improvements` - Suggest improvements for tag collections
+
+- **Schema Exploration Tools**:
+  - `get_categories` - List all tag categories
+  - `get_category_tags` - Get tags in a specific category
+  - `get_schema_stats` - Get schema statistics
+
+#### Infrastructure & Security
+- Docker support with multi-stage builds
+- GitHub Container Registry (ghcr.io) publishing
+- Trivy vulnerability scanning
+- Cosign keyless image signing
+- Multi-architecture support (amd64, arm64)
+- SARIF security reports to GitHub Security tab
+- Comprehensive test coverage (263 unit tests, 107 integration tests)
+
+#### Testing
+- JSON Data Integrity Tests against actual schema data
+- 100% coverage validation (799 tag keys, 1707 presets)
+- Bidirectional validation
+- Provider pattern for comprehensive data validation
+- Order-independent test assertions
+- Alphabetical tool ordering
+
+#### Documentation
+- Comprehensive README with badges
+- TDD methodology documentation
+- Docker usage examples
+- Security verification instructions
+
+### Changed
+- Updated repository reference and documentation structure
+- Improved test robustness with order-independent assertions
+- Enhanced tool registration with alphabetical ordering
+
+### Fixed
+- **search_tags fields.json coverage**: Now searches both fields.json and presets
+- **Alphabetical tool sorting**: Tools returned in predictable alphabetical order
+- **Tag key format**: Proper OSM colon separator format (e.g., `toilets:wheelchair`)
+- **Docker workflow**: Only runs after PR merge, not during PR review
+- **Empty preset tags**: Fixed preset matching to skip presets with empty tags
+
+## [0.1.0] - Initial Development
+
+### Added
+- Initial project setup with TypeScript 5.9
+- MCP SDK integration
+- @openstreetmap/id-tagging-schema integration
+- Schema loader with caching and indexing
+- BiomeJS 2.3.4 for code quality
+- GitHub Actions CI/CD pipeline
+- Dependabot for automated dependency updates
+- Node.js native test runner with TDD approach

--- a/README.md
+++ b/README.md
@@ -28,246 +28,24 @@ This MCP server exposes OpenStreetMap's tagging schema as a set of queryable too
 
 ## Features
 
-### Core Tools
+### 14 MCP Tools
 
-1. **Query Tag Information**
-   - Get all possible values for a specific tag key
-   - Retrieve tag descriptions and documentation
-   - Find compatible tags that work together
-   - Access tag usage guidelines
-
-2. **Preset Discovery**
-   - Search for presets by name or tags
-   - Get preset configurations and recommended tags
-   - Discover tag combinations for specific features
-
-3. **Tag Validation**
-   - Validate individual tag key-value pairs
-   - Validate complete tag collections
-   - Check for deprecated keys and suggest replacements
-   - Verify value formats and constraints
-
-4. **Schema Exploration**
-   - Browse available tag categories
-   - Search tags by keyword or category
-   - Get statistics about tag usage in schema
-
-## Development Methodology
-
-This project follows **Test-Driven Development (TDD)** principles:
-1. Write tests first before implementation
-2. Write minimal code to make tests pass
-3. Refactor while keeping tests green
-4. Maintain high test coverage (>90%)
-
-### JSON Data Integrity Testing
-
-All tools are tested against the actual JSON data from `@openstreetmap/id-tagging-schema` to ensure:
-- **Data Accuracy**: Tool outputs match the source JSON files exactly
-- **Schema Compatibility**: Tests fail if schema package updates introduce breaking changes
-- **Continuous Validation**: Every test run verifies data integrity
-
-Test categories:
-- **Unit Tests**: Validate tool logic against JSON data (presets.json, fields.json, categories.json)
-- **Integration Tests**: Verify MCP server responses match JSON data through the protocol layer
-- **Update Safety**: When `@openstreetmap/id-tagging-schema` updates, tests ensure data consistency
-
-## Development Plan
-
-### Phase 1: Project Setup ✅
-- [x] Initialize TypeScript 5.9 project with Node.js 22+
-- [x] Install dependencies:
-  - `@modelcontextprotocol/sdk`
-  - `@openstreetmap/id-tagging-schema`
-  - Development tools (BiomeJS, types)
-- [x] Set up project structure with modular file organization:
-  ```
-  src/
-  ├── index.ts              # MCP server entry point
-  ├── tools/                # Tool implementations (one file per tool)
-  │   ├── types.ts          # Shared type definitions
-  │   ├── get-schema-stats.ts
-  │   ├── get-categories.ts
-  │   ├── get-category-tags.ts
-  │   ├── get-tag-values.ts
-  │   ├── get-tag-info.ts
-  │   ├── get-related-tags.ts
-  │   ├── search-tags.ts
-  │   ├── search-presets.ts
-  │   ├── get-preset-details.ts
-  │   └── get-preset-tags.ts
-  ├── utils/                # Helper functions
-  │   ├── schema-loader.ts
-  │   └── validators.ts
-  └── types/                # TypeScript type definitions
-      └── index.ts
-  tests/                    # Test files (TDD - one test file per tool)
-  ├── tools/
-  │   ├── get-schema-stats.test.ts
-  │   ├── get-categories.test.ts
-  │   ├── get-category-tags.test.ts
-  │   ├── get-tag-values.test.ts
-  │   ├── get-tag-info.test.ts
-  │   ├── get-related-tags.test.ts
-  │   ├── search-tags.test.ts
-  │   ├── search-presets.test.ts
-  │   ├── get-preset-details.test.ts
-  │   └── get-preset-tags.test.ts
-  ├── utils/
-  │   └── schema-loader.test.ts
-  └── integration/
-      ├── helpers.ts        # Shared test utilities
-      ├── server-init.test.ts
-      ├── get-schema-stats.test.ts
-      ├── get-categories.test.ts
-      ├── get-category-tags.test.ts
-      ├── get-tag-values.test.ts
-      ├── get-tag-info.test.ts
-      ├── get-related-tags.test.ts
-      ├── search-tags.test.ts
-      ├── search-presets.test.ts
-      ├── get-preset-details.test.ts
-      └── get-preset-tags.test.ts
-  ```
-- [x] Configure build system (TypeScript compiler)
-- [x] Set up BiomeJS 2.3.4 for linting and formatting
-- [x] Configure test framework (Node.js native test runner)
-- [x] Set up GitHub Actions CI/CD
-
-### Phase 2: Schema Integration ✅
-- [x] Create schema loader utility
-- [x] Implement caching mechanism for schema data
-- [x] Build indexing system for fast tag lookups
-- [x] Create type definitions for schema structures
-- [x] Write unit tests for schema loader (19 tests passing)
-- [x] Create integration tests for MCP server
-- [x] Set up CI/CD pipeline for automated testing
-
-### Phase 3: Core Tool Implementation - IN PROGRESS ⏳
-
-#### 3.1 Tag Query Tools
-- [x] `get_tag_info`: Get information about a specific tag key ✅
-  - Input: tag key (e.g., "parking")
-  - Output: all possible values, type, and field definition status
-- [x] `get_tag_values`: Get all possible values for a tag key ✅
-  - Input: tag key
-  - Output: array of valid values sorted alphabetically
-- [x] `get_related_tags`: Find tags commonly used together ✅
-  - Input: tag key or key-value pair
-  - Output: related tags sorted by frequency with preset examples
-- [x] `search_tags`: Search for tags by keyword ✅
-  - Input: search query, optional limit
-  - Output: matching tags from fields and presets with key, value, and preset name
-
-#### 3.2 Preset Tools
-- [x] `search_presets`: Search for presets by name or tags ✅
-  - Input: search query or tag filters
-  - Output: matching presets with metadata
-- [x] `get_preset_details`: Get complete preset information ✅
-  - Input: preset ID or name
-  - Output: preset configuration, tags, fields
-- [x] `get_preset_tags`: Get recommended tags for a preset ✅
-  - Input: preset ID
-  - Output: required and optional tags
-
-#### 3.3 Validation Tools
-- [x] `validate_tag`: Validate a single tag key-value pair ✅
-  - Input: key and value
-  - Output: validation result with errors/warnings, deprecation info
-- [x] `validate_tag_collection`: Validate a collection of tags ✅
-  - Input: object with key-value pairs
-  - Output: validation report with all issues, aggregated statistics
-- [x] `check_deprecated`: Check if tags are deprecated ✅
-  - Input: tag key or key-value pair
-  - Output: deprecation status, old tags, and suggested replacements
-- [x] `suggest_improvements`: Suggest improvements for tag collection ✅
-  - Input: tag collection
-  - Output: recommendations, warnings, and matched presets
-
-#### 3.4 Schema Exploration Tools
-- [x] `get_categories`: List all tag categories ✅
-  - Output: array of categories with names and member counts, sorted alphabetically
-- [x] `get_category_tags`: Get tags in a specific category ✅
-  - Input: category name
-  - Output: preset IDs belonging to that category
-- [x] `get_schema_stats`: Get schema statistics ✅
-  - Output: counts of presets, fields, categories, and deprecated items
-
-### Phase 4: Testing (TDD Approach) - COMPLETED ✅
-- [x] Configure Node.js native test runner
-- [x] Write unit tests for schema loader (19 tests passing)
-- [x] Write unit tests for all implemented tools (170 tests, 66 suites passing)
-- [x] Create integration tests for MCP server (59 tests, 31 suites passing)
-  - **Modular structure**: One integration test file per tool for clarity
-  - **Shared utilities**: `helpers.ts` for common setup/teardown
-  - **Order-independent tests**: Tools validated by existence, not array position
-  - **Alphabetical ordering**: Tools returned in predictable alphabetical order
-- [x] Test with real OpenStreetMap tag data
-- [x] Set up CI/CD pipeline with GitHub Actions
-- [x] **JSON Data Integrity Tests**: Verify all tool outputs match source JSON data
-  - Unit tests validate against @openstreetmap/id-tagging-schema JSON files
-  - Integration tests verify MCP tool responses match JSON data exactly
-  - Tests ensure compatibility with schema package updates
-  - Provider pattern for comprehensive data validation
-  - 100% coverage: ALL tag keys (799) + ALL presets (1707) validated (no hardcoded samples)
-  - Bidirectional validation ensures complete data integrity
-- [x] Validate error handling for all implemented tools
-- [x] Achieve high test coverage across all modules (>90%)
-
-### Phase 5: Documentation
-- [ ] Write API documentation for each tool
-- [ ] Create usage examples
-- [ ] Document installation and setup
-- [ ] Add troubleshooting guide
-- [ ] Create contribution guidelines
-
-### Phase 6: Optimization & Polish
-- [ ] Implement caching strategies
-- [ ] Optimize schema loading and queries
-- [ ] Add logging and debugging support
-- [ ] Handle schema updates gracefully
-- [ ] Prepare for publication
-
-### Phase 7: Distribution & Deployment
-- [ ] **NPM Publishing with Provenance**
-  - Set up GitHub Actions workflow for npm publishing
-  - Configure npm provenance signing (attestations)
-  - Link package to GitHub repository with verified builds
-  - Enable trusted publishing from GitHub Actions
-  - Add package provenance badge to README
-- [ ] **Container Image & Registry**
-  - Create Dockerfile for containerized deployment
-  - Set up multi-stage builds for optimal image size
-  - Publish to GitHub Container Registry (ghcr.io)
-  - Add container image scanning for security
-  - Support for multiple architectures (amd64, arm64)
-- [ ] **Additional Transport Protocols**
-  - Implement Server-Sent Events (SSE) transport
-  - Implement HTTP/REST transport for web clients
-  - Add WebSocket transport support
-  - Create transport configuration system
-  - Document transport selection and use cases
-- [ ] **Public Service Deployment**
-  - Create deployment configurations (Docker Compose, Kubernetes)
-  - Set up health check endpoints
-  - Configure rate limiting and authentication
-  - Add metrics and monitoring (Prometheus/Grafana)
-  - Create deployment documentation
-  - Plan for horizontal scaling
-
-### Future Enhancements
-
-**Schema-Builder Inspired Features** (planned for future phases):
-
-Based on analysis of [ideditor/schema-builder](https://github.com/ideditor/schema-builder), the following advanced features are planned:
-
-1. **Enhanced Tag Validation** - Geometry constraints, prerequisite tag checking, field type validation
-2. **Field Inheritance Resolution** - Complete field lists including inherited fields from parent presets
-3. **Conditional Field Analysis** - Determine field visibility based on tag values and prerequisites
-4. **Advanced Deprecation** - Complex tag transformations with placeholder substitution
-5. **Tag Quality Scoring** - Completeness and quality scoring for features
-
-These enhancements will extend validation capabilities while maintaining 100% compatibility with current implementation. See `CLAUDE.md` for detailed specifications.
+| Category | Tool | Description |
+|----------|------|-------------|
+| **Tag Query** | `get_tag_info` | Get comprehensive information about a tag key (values, type, field definition) |
+| | `get_tag_values` | Get all possible values for a tag key |
+| | `get_related_tags` | Find tags commonly used together with frequency counts |
+| | `search_tags` | Search for tags by keyword in fields and presets |
+| **Preset Discovery** | `search_presets` | Search presets by keyword or tag with optional geometry filtering |
+| | `get_preset_details` | Get complete preset configuration (tags, geometry, fields, metadata) |
+| | `get_preset_tags` | Get recommended tags for a preset (identifying tags + addTags) |
+| **Validation** | `validate_tag` | Validate a single tag key-value pair |
+| | `validate_tag_collection` | Validate complete tag collections with aggregated statistics |
+| | `check_deprecated` | Check if tags are deprecated with replacement suggestions |
+| | `suggest_improvements` | Suggest improvements for tag collections (missing fields, warnings) |
+| **Schema Exploration** | `get_categories` | List all tag categories with counts |
+| | `get_category_tags` | Get tags in a specific category |
+| | `get_schema_stats` | Get schema statistics (counts of presets, fields, categories, deprecated items) |
 
 ## Installation
 
@@ -375,7 +153,146 @@ Alternatively, you can manually add to your MCP client configuration:
 - **Claude Desktop (macOS):** `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Claude Desktop (Windows):** `%APPDATA%\Claude\claude_desktop_config.json`
 
-### Development
+### Example Queries
+
+<details>
+<summary><b>Query tag information</b></summary>
+
+```typescript
+// Get information about the "parking" tag
+{
+  "tool": "get_tag_info",
+  "arguments": {
+    "key": "parking"
+  }
+}
+// Returns: all possible values (surface, underground, multi-storey, etc.)
+// and compatible tags (capacity, fee, operator, etc.)
+```
+</details>
+
+<details>
+<summary><b>Search for presets</b></summary>
+
+```typescript
+// Search for restaurant presets
+{
+  "tool": "search_presets",
+  "arguments": {
+    "keyword": "restaurant"
+  }
+}
+// Returns: amenity/restaurant, amenity/fast_food, and other matching presets
+```
+</details>
+
+<details>
+<summary><b>Get preset details</b></summary>
+
+```typescript
+// Get complete information about a preset
+{
+  "tool": "get_preset_details",
+  "arguments": {
+    "presetId": "amenity/restaurant"
+  }
+}
+// Returns: id, tags, geometry types, fields, icon, and other metadata
+```
+</details>
+
+<details>
+<summary><b>Validate tags</b></summary>
+
+```typescript
+// Validate a collection of tags
+{
+  "tool": "validate_tag_collection",
+  "arguments": {
+    "tags": {
+      "amenity": "parking",
+      "parking": "surface",
+      "capacity": "50",
+      "fee": "yes"
+    }
+  }
+}
+// Returns: validation result with any errors or warnings
+```
+</details>
+
+<details>
+<summary><b>Suggest improvements</b></summary>
+
+```typescript
+// Get suggestions for a tag collection
+{
+  "tool": "suggest_improvements",
+  "arguments": {
+    "tags": {
+      "amenity": "restaurant"
+    }
+  }
+}
+// Returns: suggestions for missing fields, deprecation warnings, matched presets
+```
+</details>
+
+## Development Methodology
+
+This project follows **Test-Driven Development (TDD)** principles:
+1. Write tests first before implementation
+2. Write minimal code to make tests pass
+3. Refactor while keeping tests green
+4. Maintain high test coverage (>90%)
+
+### Test Statistics
+- **Unit Tests**: 263 tests, 111 suites passing
+- **Integration Tests**: 107 tests, 55 suites passing
+- **Total**: 370 tests with 100% passing rate
+
+### JSON Data Integrity Testing
+
+All tools are tested against the actual JSON data from `@openstreetmap/id-tagging-schema` to ensure:
+- **Data Accuracy**: Tool outputs match the source JSON files exactly
+- **Schema Compatibility**: Tests fail if schema package updates introduce breaking changes
+- **100% Coverage**: ALL tag keys (799) + ALL presets (1707) validated (no hardcoded samples)
+- **Continuous Validation**: Every test run verifies data integrity
+
+## Technical Stack
+
+- **Runtime**: Node.js 22+
+- **Language**: TypeScript 5.9
+- **MCP SDK**: @modelcontextprotocol/sdk ^1.0.4
+- **Schema Library**: @openstreetmap/id-tagging-schema ^6.7.3
+- **Build Tool**: TypeScript compiler
+- **Testing**: Node.js native test runner (TDD methodology)
+- **Code Quality**: BiomeJS 2.3.4 (linting & formatting)
+- **CI/CD**: GitHub Actions (automated testing, Docker builds)
+- **Dependencies**: Dependabot (automated updates)
+- **Distribution**: npm registry (via npx), GitHub Container Registry (Docker images)
+- **Containerization**: Docker with multistage builds (Alpine Linux base)
+
+## Architecture
+
+### Modular File Organization
+
+**One Tool, One File**: Each MCP tool is implemented in a separate file with a corresponding test file. This modular approach ensures:
+- **Clarity**: Easy to locate and understand individual tool implementations
+- **Maintainability**: Changes to one tool don't affect others
+- **Scalability**: New tools can be added without modifying existing files
+- **Testability**: Each tool has dedicated tests that can run independently
+
+### Architectural Layers
+
+The server follows a modular architecture with distinct layers:
+
+1. **Schema Layer**: Loads and indexes the tagging schema
+2. **Tool Layer**: Implements MCP tools that query the schema (one file per tool)
+3. **Validation Layer**: Provides tag validation logic
+4. **Server Layer**: MCP server setup and tool registration
+
+## Development
 
 ```bash
 # Install dependencies
@@ -400,165 +317,30 @@ npm run typecheck
 npm run build
 ```
 
-### Example Queries
-
-**Query tag information:**
-```typescript
-// Get information about the "parking" tag
-{
-  "tool": "get_tag_info",
-  "arguments": {
-    "key": "parking"
-  }
-}
-// Returns: all possible values (surface, underground, multi-storey, etc.)
-// and compatible tags (capacity, fee, operator, etc.)
-```
-
-**Search for presets:**
-```typescript
-// Search for restaurant presets
-{
-  "tool": "search_presets",
-  "arguments": {
-    "keyword": "restaurant"
-  }
-}
-// Returns: amenity/restaurant, amenity/fast_food, and other matching presets
-```
-
-**Get preset details:**
-```typescript
-// Get complete information about a preset
-{
-  "tool": "get_preset_details",
-  "arguments": {
-    "presetId": "amenity/restaurant"
-  }
-}
-// Returns: id, tags, geometry types, fields, icon, and other metadata
-```
-
-**Validate tags:**
-```typescript
-// Validate a collection of tags
-{
-  "tool": "validate_tag_collection",
-  "arguments": {
-    "tags": {
-      "amenity": "parking",
-      "parking": "surface",
-      "capacity": "50",
-      "fee": "yes"
-    }
-  }
-}
-// Returns: validation result with any errors or warnings
-```
-
-## Technical Stack
-
-- **Runtime**: Node.js 22+
-- **Language**: TypeScript 5.9
-- **MCP SDK**: @modelcontextprotocol/sdk
-- **Schema Library**: @openstreetmap/id-tagging-schema
-- **Build Tool**: TypeScript compiler
-- **Testing**: Node.js native test runner (TDD methodology)
-- **Code Quality**: BiomeJS 2.3.4 (linting & formatting)
-- **CI/CD**: GitHub Actions (automated testing)
-- **Dependencies**: Dependabot (automated updates)
-- **Distribution**: npm (via npx)
-
-## Architecture
-
-### Modular File Organization
-
-**One Tool, One File**: Each MCP tool is implemented in a separate file with a corresponding test file. This modular approach ensures:
-- **Clarity**: Easy to locate and understand individual tool implementations
-- **Maintainability**: Changes to one tool don't affect others
-- **Scalability**: New tools can be added without modifying existing files
-- **Testability**: Each tool has dedicated tests that can run independently
-
-```
-src/tools/
-├── types.ts                  # Shared type definitions
-├── get-schema-stats.ts       # get_schema_stats tool
-├── get-categories.ts         # get_categories tool
-├── get-category-tags.ts      # get_category_tags tool
-├── get-tag-values.ts         # get_tag_values tool
-├── get-tag-info.ts           # get_tag_info tool
-├── get-related-tags.ts       # get_related_tags tool
-├── search-tags.ts            # search_tags tool
-├── search-presets.ts         # search_presets tool
-├── get-preset-details.ts     # get_preset_details tool
-└── get-preset-tags.ts        # get_preset_tags tool
-
-tests/tools/
-├── get-schema-stats.test.ts  # Tests for get_schema_stats
-├── get-categories.test.ts    # Tests for get_categories
-├── get-category-tags.test.ts # Tests for get_category_tags
-├── get-tag-values.test.ts    # Tests for get_tag_values
-├── get-tag-info.test.ts      # Tests for get_tag_info
-├── get-related-tags.test.ts  # Tests for get_related_tags
-├── search-tags.test.ts       # Tests for search_tags
-├── search-presets.test.ts    # Tests for search_presets
-├── get-preset-details.test.ts # Tests for get_preset_details
-└── get-preset-tags.test.ts   # Tests for get_preset_tags
-
-tests/integration/
-├── helpers.ts                # Shared test utilities
-├── server-init.test.ts       # Server initialization tests
-├── get-schema-stats.test.ts  # get_schema_stats integration
-├── get-categories.test.ts    # get_categories integration
-├── get-category-tags.test.ts # get_category_tags integration
-├── get-tag-values.test.ts    # get_tag_values integration
-├── get-tag-info.test.ts      # get_tag_info integration
-├── get-related-tags.test.ts  # get_related_tags integration
-├── search-tags.test.ts       # search_tags integration
-├── search-presets.test.ts    # search_presets integration
-├── get-preset-details.test.ts # get_preset_details integration
-└── get-preset-tags.test.ts   # get_preset_tags integration
-```
-
-### Architectural Layers
-
-The server follows a modular architecture with distinct layers:
-
-1. **Schema Layer**: Loads and indexes the tagging schema
-2. **Tool Layer**: Implements MCP tools that query the schema (one file per tool)
-3. **Validation Layer**: Provides tag validation logic
-4. **Server Layer**: MCP server setup and tool registration
-
 ## CI/CD Pipeline
 
 This project uses GitHub Actions for continuous integration and delivery:
 
-### Automated Testing
-- Runs on every push and pull request
-- Executes full test suite with Node.js test runner
-- Checks code quality with BiomeJS
-- Validates TypeScript compilation
-- Ensures test coverage >90%
+- **Automated Testing**: Runs on every push and pull request
+- **Code Quality**: BiomeJS checks for linting and formatting issues
+- **TypeScript Validation**: Ensures compilation succeeds
+- **Dependabot**: Automated dependency updates and security patches
+- **Docker Builds**: Automated container builds with Trivy scanning and Cosign signing
+- **Release Process**: Automated releases to npm registry with semantic versioning
 
-### Dependabot
-- Automatically checks for dependency updates
-- Creates pull requests for security patches
-- Keeps dependencies up to date
+## Project Status
 
-### Release Process
-- Automated releases to npm registry
-- Semantic versioning
-- Changelog generation
-- Package available via `npx` command
+**Current Phase**: Phase 3 ✅ Complete (All 14 tools implemented)
 
-### Workflow Files
-```
-.github/
-├── workflows/
-│   ├── test.yml           # Run tests on push/PR
-│   ├── release.yml        # Automated npm releases
-│   └── dependabot.yml     # Dependency updates
-```
+- ✅ Phase 1: Project Setup
+- ✅ Phase 2: Schema Integration
+- ✅ Phase 3: Core Tool Implementation
+- ✅ Phase 4: Testing
+- 🚧 Phase 5: Documentation (In Progress)
+- 📋 Phase 6: Optimization & Polish
+- 📋 Phase 7: Distribution & Deployment
+
+See [ROADMAP.md](./ROADMAP.md) for detailed development plan.
 
 ## Contributing
 
@@ -574,9 +356,15 @@ Contributions are welcome! Please follow these guidelines:
 8. **Commit changes**: Use conventional commit messages
 9. **Submit a PR**: Include description and test coverage
 
+## Documentation
+
+- [ROADMAP.md](./ROADMAP.md) - Development roadmap and future plans
+- [CHANGELOG.md](./CHANGELOG.md) - Project changelog
+- [CLAUDE.md](./CLAUDE.md) - Technical project documentation and development notes
+
 ## License
 
-GNU General Public License v3.0 - See LICENSE file for details
+GNU General Public License v3.0 - See [LICENSE](./LICENSE) file for details
 
 ## Resources
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,150 @@
+# Development Roadmap
+
+This document outlines the development phases for the OSM Tagging Schema MCP Server.
+
+## Phase 1: Project Setup ✅
+
+- [x] Initialize TypeScript 5.9 project with Node.js 22+
+- [x] Install dependencies:
+  - `@modelcontextprotocol/sdk`
+  - `@openstreetmap/id-tagging-schema`
+  - Development tools (BiomeJS, types)
+- [x] Set up project structure with modular file organization
+- [x] Configure build system (TypeScript compiler)
+- [x] Set up BiomeJS 2.3.4 for linting and formatting
+- [x] Configure test framework (Node.js native test runner)
+- [x] Set up GitHub Actions CI/CD
+
+## Phase 2: Schema Integration ✅
+
+- [x] Create schema loader utility
+- [x] Implement caching mechanism for schema data
+- [x] Build indexing system for fast tag lookups
+- [x] Create type definitions for schema structures
+- [x] Write unit tests for schema loader (19 tests passing)
+- [x] Create integration tests for MCP server
+- [x] Set up CI/CD pipeline for automated testing
+
+## Phase 3: Core Tool Implementation ✅
+
+### 3.1 Tag Query Tools
+- [x] `get_tag_info` - Get information about a specific tag key
+- [x] `get_tag_values` - Get all possible values for a tag key
+- [x] `get_related_tags` - Find tags commonly used together
+- [x] `search_tags` - Search for tags by keyword
+
+### 3.2 Preset Tools
+- [x] `search_presets` - Search for presets by name or tags
+- [x] `get_preset_details` - Get complete preset information
+- [x] `get_preset_tags` - Get recommended tags for a preset
+
+### 3.3 Validation Tools
+- [x] `validate_tag` - Validate a single tag key-value pair
+- [x] `validate_tag_collection` - Validate a collection of tags
+- [x] `check_deprecated` - Check if tags are deprecated
+- [x] `suggest_improvements` - Suggest improvements for tag collection
+
+### 3.4 Schema Exploration Tools
+- [x] `get_categories` - List all tag categories
+- [x] `get_category_tags` - Get tags in a specific category
+- [x] `get_schema_stats` - Get schema statistics
+
+## Phase 4: Testing ✅
+
+- [x] Configure Node.js native test runner
+- [x] Write unit tests for schema loader (19 tests passing)
+- [x] Write unit tests for all implemented tools (263 tests, 111 suites passing)
+- [x] Create integration tests for MCP server (107 tests, 55 suites passing)
+  - Modular structure: One integration test file per tool
+  - Shared utilities: `helpers.ts` for common setup/teardown
+  - Order-independent tests: Tools validated by existence, not array position
+  - Alphabetical ordering: Tools returned in predictable alphabetical order
+- [x] Test with real OpenStreetMap tag data
+- [x] Set up CI/CD pipeline with GitHub Actions
+- [x] **JSON Data Integrity Tests**: Verify all tool outputs match source JSON data
+  - Unit tests validate against @openstreetmap/id-tagging-schema JSON files
+  - Integration tests verify MCP tool responses match JSON data exactly
+  - Tests ensure compatibility with schema package updates
+  - Provider pattern for comprehensive data validation
+  - 100% coverage: ALL tag keys (799) + ALL presets (1707) validated (no hardcoded samples)
+  - Bidirectional validation ensures complete data integrity
+- [x] Validate error handling for all implemented tools
+- [x] Achieve high test coverage across all modules (>90%)
+
+## Phase 5: Documentation
+
+- [ ] Write API documentation for each tool
+- [ ] Create usage examples
+- [ ] Document installation and setup
+- [ ] Add troubleshooting guide
+- [ ] Create contribution guidelines
+
+## Phase 6: Optimization & Polish
+
+- [ ] Implement caching strategies
+- [ ] Optimize schema loading and queries
+- [ ] Add logging and debugging support
+- [ ] Handle schema updates gracefully
+- [ ] Prepare for publication
+
+## Phase 7: Distribution & Deployment
+
+### NPM Publishing with Provenance
+- [ ] Set up GitHub Actions workflow for npm publishing
+- [ ] Configure npm provenance signing (attestations)
+- [ ] Link package to GitHub repository with verified builds
+- [ ] Enable trusted publishing from GitHub Actions
+- [ ] Add package provenance badge to README
+
+### Container Image & Registry
+- [x] Create Dockerfile for containerized deployment
+- [x] Set up multi-stage builds for optimal image size
+- [x] Publish to GitHub Container Registry (ghcr.io)
+- [x] Add container image scanning for security (Trivy)
+- [x] Support for multiple architectures (amd64, arm64)
+- [x] Image signing with Cosign (keyless OIDC)
+- [x] SARIF security reports uploaded to GitHub
+
+### Additional Transport Protocols
+- [ ] Implement Server-Sent Events (SSE) transport
+- [ ] Implement HTTP/REST transport for web clients
+- [ ] Add WebSocket transport support
+- [ ] Create transport configuration system
+- [ ] Document transport selection and use cases
+
+### Public Service Deployment
+- [ ] Create deployment configurations (Docker Compose, Kubernetes)
+- [ ] Set up health check endpoints
+- [ ] Configure rate limiting and authentication
+- [ ] Add metrics and monitoring (Prometheus/Grafana)
+- [ ] Create deployment documentation
+- [ ] Plan for horizontal scaling
+
+## Future Enhancements
+
+Based on analysis of [ideditor/schema-builder](https://github.com/ideditor/schema-builder), the following advanced features are planned:
+
+### Enhanced Tag Validation
+- Geometry constraints validation
+- Prerequisite tag checking
+- Field type constraints validation
+
+### Field Inheritance Resolution
+- Complete field lists including inherited fields from parent presets
+- Preset inheritance chain resolution
+
+### Conditional Field Analysis
+- Determine field visibility based on tag values
+- Handle complex prerequisite logic
+
+### Advanced Deprecation Transformations
+- Placeholder substitution support (`$1`, `$2`)
+- Multi-tag replacements
+- Conditional replacements based on additional context
+
+### Tag Quality Scoring
+- Completeness and quality scoring for features
+- Missing required/important field detection
+- Common optional field suggestions
+
+These enhancements will extend validation capabilities while maintaining 100% compatibility with current implementation.


### PR DESCRIPTION
**Changes**:
- Moved development plan from README.md to ROADMAP.md (without time estimates)
- Created CHANGELOG.md following Keep a Changelog format
- Converted tools list to table format in README for better readability
- Made README more compact and focused on essential information
- Added links to ROADMAP.md, CHANGELOG.md, and CLAUDE.md

**README.md**:
- Tools organized in a clean table by category (Tag Query, Preset Discovery, Validation, Schema Exploration)
- Collapsed example queries into expandable sections (<details>)
- Removed detailed development plan (now in ROADMAP.md)
- Removed future enhancements details (still referenced, details in ROADMAP.md)
- Added "Documentation" section with links to all documentation files
- Improved readability and navigation

**ROADMAP.md** (NEW):
- Complete development plan with all 7 phases
- Detailed breakdown of each phase's tasks
- Current status tracking (Phase 3 complete)
- Future enhancements section
- No time estimates (as requested)

**CHANGELOG.md** (NEW):
- Follows Keep a Changelog format
- Unreleased section with all current features
- Organized by Added/Changed/Fixed categories
- Tracks Phase 3 tools, infrastructure, testing, and bug fixes
- Initial 0.1.0 release section

**Result**: Better organized documentation with clear separation of concerns