### PR TITLE
feat: implement Streamable HTTP transport with environment variable s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,27 @@ Ask Claude: "Validate these tags: amenity=parking, capacity=50"
 - [docs/usage.md](./docs/usage.md) - Complete usage examples and workflows
 - [docs/api/](./docs/api/) - API reference for all 14 tools
 
+## HTTP Transport
+
+The server supports HTTP transport with Server-Sent Events (SSE) in addition to the default stdio transport:
+
+```bash
+# Start with HTTP transport
+TRANSPORT=http npm start
+
+# Custom port and host
+TRANSPORT=http HTTP_PORT=8080 HTTP_HOST=0.0.0.0 npm start
+
+# Using Docker
+docker run -e TRANSPORT=http -p 3000:3000 ghcr.io/gander-tools/osm-tagging-schema-mcp:dev
+```
+
+📖 **For complete HTTP transport documentation**, see [docs/http-transport.md](./docs/http-transport.md) which covers:
+- Configuration options (port, host, CORS, session management)
+- API endpoints and usage
+- Integration examples (JavaScript, Python)
+- Security considerations
+
 ## Development Methodology
 
 This project follows **Test-Driven Development (TDD)** principles:

--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -1,0 +1,335 @@
+# HTTP Transport
+
+The OSM Tagging Schema MCP Server supports HTTP transport with Server-Sent Events (SSE) in addition to the default stdio transport.
+
+## Configuration
+
+HTTP transport is configured using environment variables:
+
+| Variable | Description | Default | Values |
+|----------|-------------|---------|--------|
+| `TRANSPORT` | Transport protocol to use | `stdio` | `stdio`, `http` |
+| `HTTP_PORT` | HTTP server port | `3000` | `1-65535` |
+| `HTTP_HOST` | HTTP server host | `0.0.0.0` | Any valid hostname or IP |
+| `HTTP_SESSION_MODE` | Session management mode | `stateful` | `stateful`, `stateless` |
+| `HTTP_CORS_ENABLED` | Enable CORS | `true` | `true`, `false` |
+| `HTTP_CORS_ORIGIN` | CORS origin header | `*` | Any origin string |
+
+## Usage
+
+### Starting the Server
+
+```bash
+# Start with HTTP transport
+TRANSPORT=http npm start
+
+# Start with custom port
+TRANSPORT=http HTTP_PORT=8080 npm start
+
+# Start with specific host
+TRANSPORT=http HTTP_HOST=127.0.0.1 npm start
+
+# Stateless mode (no session management)
+TRANSPORT=http HTTP_SESSION_MODE=stateless npm start
+```
+
+### Docker
+
+```bash
+# Using docker run
+docker run -e TRANSPORT=http -p 3000:3000 ghcr.io/gander-tools/osm-tagging-schema-mcp:latest
+
+# Using docker compose
+services:
+  osm-mcp:
+    image: ghcr.io/gander-tools/osm-tagging-schema-mcp:latest
+    environment:
+      - TRANSPORT=http
+      - HTTP_PORT=3000
+      - HTTP_HOST=0.0.0.0
+    ports:
+      - "3000:3000"
+```
+
+## Endpoints
+
+### Health Check
+
+```http
+GET /health
+```
+
+Returns server health status.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "timestamp": "2025-11-10T12:00:00.000Z",
+  "version": "0.1.0"
+}
+```
+
+### MCP Protocol
+
+All MCP requests are handled via the `/mcp` endpoint using the [Streamable HTTP](https://spec.modelcontextprotocol.io/specification/2025-03-26/transports/#http-with-sse) transport specification.
+
+#### POST /mcp
+
+Send JSON-RPC 2.0 requests.
+
+**Required Headers:**
+- `Content-Type: application/json`
+- `Mcp-Protocol-Version: 2025-03-26` (or other supported version)
+- `Accept: application/json, text/event-stream`
+
+**Session Management (Stateful Mode):**
+- Initialization requests receive `Mcp-Session-Id` header in response
+- Subsequent requests must include `Mcp-Session-Id` header
+
+**Example: Initialization**
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Protocol-Version: 2025-03-26" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-03-26",
+      "capabilities": {},
+      "clientInfo": {
+        "name": "test-client",
+        "version": "1.0.0"
+      }
+    }
+  }'
+```
+
+**Example: Tool Call**
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Protocol-Version: 2025-03-26" \
+  -H "Mcp-Session-Id: <session-id-from-init>" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/call",
+    "params": {
+      "name": "get_schema_stats",
+      "arguments": {}
+    }
+  }'
+```
+
+#### GET /mcp
+
+Establish Server-Sent Events (SSE) stream for receiving server notifications.
+
+**Required Headers:**
+- `Mcp-Session-Id: <session-id>`
+- `Accept: text/event-stream`
+
+#### DELETE /mcp
+
+Terminate a session.
+
+**Required Headers:**
+- `Mcp-Session-Id: <session-id>`
+
+## CORS Configuration
+
+CORS (Cross-Origin Resource Sharing) is enabled by default to allow browser-based clients.
+
+```bash
+# Disable CORS
+TRANSPORT=http HTTP_CORS_ENABLED=false npm start
+
+# Restrict to specific origin
+TRANSPORT=http HTTP_CORS_ORIGIN=https://example.com npm start
+```
+
+## Session Management
+
+### Stateful Mode (Default)
+
+- Server generates and manages session IDs
+- Clients receive `Mcp-Session-Id` header during initialization
+- Session state is maintained in memory
+- Sessions persist until explicitly terminated or server restart
+
+### Stateless Mode
+
+- No session management
+- No `Mcp-Session-Id` headers
+- Each request is independent
+- Suitable for simple request/response scenarios
+
+```bash
+TRANSPORT=http HTTP_SESSION_MODE=stateless npm start
+```
+
+## Protocol Support
+
+The server implements the [MCP Streamable HTTP specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/transports/#http-with-sse) using the official MCP SDK.
+
+**Supported Protocol Versions:**
+- `2025-03-26` (latest, default)
+- `2024-11-05`
+- `2024-10-07`
+
+## Integration Examples
+
+### JavaScript/TypeScript
+
+```typescript
+import fetch from 'node-fetch';
+
+const baseUrl = 'http://localhost:3000';
+
+// Initialize session
+const initResponse = await fetch(`${baseUrl}/mcp`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Mcp-Protocol-Version': '2025-03-26',
+    'Accept': 'application/json, text/event-stream',
+  },
+  body: JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-03-26',
+      capabilities: {},
+      clientInfo: { name: 'my-client', version: '1.0.0' },
+    },
+  }),
+});
+
+const sessionId = initResponse.headers.get('mcp-session-id');
+
+// Call tool
+const toolResponse = await fetch(`${baseUrl}/mcp`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Mcp-Protocol-Version': '2025-03-26',
+    'Mcp-Session-Id': sessionId,
+    'Accept': 'application/json, text/event-stream',
+  },
+  body: JSON.stringify({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: {
+      name: 'get_tag_info',
+      arguments: { tagKey: 'amenity' },
+    },
+  }),
+});
+
+const result = await toolResponse.json();
+console.log(result);
+```
+
+### Python
+
+```python
+import requests
+
+base_url = 'http://localhost:3000'
+
+# Initialize session
+init_response = requests.post(
+    f'{base_url}/mcp',
+    headers={
+        'Content-Type': 'application/json',
+        'Mcp-Protocol-Version': '2025-03-26',
+        'Accept': 'application/json, text/event-stream',
+    },
+    json={
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': 'initialize',
+        'params': {
+            'protocolVersion': '2025-03-26',
+            'capabilities': {},
+            'clientInfo': {'name': 'my-client', 'version': '1.0.0'},
+        },
+    },
+)
+
+session_id = init_response.headers.get('Mcp-Session-Id')
+
+# Call tool
+tool_response = requests.post(
+    f'{base_url}/mcp',
+    headers={
+        'Content-Type': 'application/json',
+        'Mcp-Protocol-Version': '2025-03-26',
+        'Mcp-Session-Id': session_id,
+        'Accept': 'application/json, text/event-stream',
+    },
+    json={
+        'jsonrpc': '2.0',
+        'id': 2,
+        'method': 'tools/call',
+        'params': {
+            'name': 'get_tag_info',
+            'arguments': {'tagKey': 'amenity'},
+        },
+    },
+)
+
+result = tool_response.json()
+print(result)
+```
+
+## Security Considerations
+
+- **Bind Address**: Use `HTTP_HOST=127.0.0.1` for local-only access
+- **Firewall**: Ensure proper firewall rules when exposing publicly
+- **CORS**: Restrict origins in production environments
+- **Authentication**: Consider adding authentication middleware for production use
+- **TLS**: Use reverse proxy (nginx, Apache) for HTTPS in production
+
+## Troubleshooting
+
+### Server won't start
+
+```bash
+# Check if port is already in use
+lsof -i :3000
+
+# Try different port
+TRANSPORT=http HTTP_PORT=8080 npm start
+```
+
+### Connection refused
+
+```bash
+# Check if server is listening on correct interface
+# Use 0.0.0.0 to listen on all interfaces
+TRANSPORT=http HTTP_HOST=0.0.0.0 npm start
+```
+
+### CORS errors in browser
+
+```bash
+# Enable CORS and set appropriate origin
+TRANSPORT=http HTTP_CORS_ENABLED=true HTTP_CORS_ORIGIN=https://your-domain.com npm start
+```
+
+## See Also
+
+- [Installation Guide](installation.md)
+- [Configuration Guide](configuration.md)
+- [API Reference](api/README.md)
+- [MCP Specification](https://spec.modelcontextprotocol.io/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,17 @@
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "~1.21.1",
-				"@openstreetmap/id-tagging-schema": "~6.7.3"
+				"@openstreetmap/id-tagging-schema": "~6.7.3",
+				"cors": "^2.8.5",
+				"express": "^5.1.0"
 			},
 			"bin": {
 				"osm-tagging-mcp": "dist/index.js"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.3.4",
+				"@types/cors": "^2.8.19",
+				"@types/express": "^5.0.5",
 				"@types/node": "^24.10.0",
 				"tsx": "^4.19.2",
 				"typescript": "^5.7.2"
@@ -141,6 +145,76 @@
 			"integrity": "sha512-2oYAXEqmnQd/J4iWYq0dp08Jd8XtOvyGm91fF9KJNbJW4IDRq9JgxAOxMizHG6cS9VrbZWndaMvoeIx94NiY8w==",
 			"license": "ISC"
 		},
+		"node_modules/@types/body-parser": {
+			"version": "1.19.6",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+			"integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/connect": {
+			"version": "3.4.38",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+			"integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/cors": {
+			"version": "2.8.19",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+			"integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/express": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.5.tgz",
+			"integrity": "sha512-LuIQOcb6UmnF7C1PCFmEU1u2hmiHL43fgFQX67sN3H4Z+0Yk0Neo++mFsBjhOAuLzvlQeqAAkeDOZrJs9rzumQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^5.0.0",
+				"@types/serve-static": "^1"
+			}
+		},
+		"node_modules/@types/express-serve-static-core": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
+			"integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*",
+				"@types/send": "*"
+			}
+		},
+		"node_modules/@types/http-errors": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+			"integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/mime": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+			"integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "24.10.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
@@ -149,6 +223,53 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
+			}
+		},
+		"node_modules/@types/qs": {
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+			"integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/range-parser": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/serve-static": {
+			"version": "1.15.10",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+			"integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-errors": "*",
+				"@types/node": "*",
+				"@types/send": "<1"
+			}
+		},
+		"node_modules/@types/serve-static/node_modules/@types/send": {
+			"version": "0.17.6",
+			"resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+			"integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime": "^1",
+				"@types/node": "*"
 			}
 		},
 		"node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -53,10 +53,14 @@
 	],
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "~1.21.1",
-		"@openstreetmap/id-tagging-schema": "~6.7.3"
+		"@openstreetmap/id-tagging-schema": "~6.7.3",
+		"cors": "^2.8.5",
+		"express": "^5.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.4",
+		"@types/cors": "^2.8.19",
+		"@types/express": "^5.0.5",
 		"@types/node": "^24.10.0",
 		"tsx": "^4.19.2",
 		"typescript": "^5.7.2"

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -1,0 +1,244 @@
+/**
+ * HTTP Transport for MCP Server
+ * Provides Streamable HTTP with SSE support using Express
+ */
+
+import express, { type Request, type Response } from "express";
+import cors from "cors";
+import { randomUUID } from "node:crypto";
+import type { Server as NodeServer } from "node:http";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { logger } from "../utils/logger.js";
+import type { HTTPConfig } from "../utils/transport-config.js";
+
+/**
+ * Map to store active transports by session ID
+ */
+const transports = new Map<string, StreamableHTTPServerTransport>();
+
+/**
+ * Health check response interface
+ */
+interface HealthCheckResponse {
+	status: "ok";
+	timestamp: string;
+	version: string;
+}
+
+/**
+ * Start HTTP server with MCP support
+ * @param mcpServer The MCP server instance
+ * @param config HTTP configuration
+ * @returns Promise<NodeServer> The HTTP server instance
+ */
+export async function startHttpServer(
+	mcpServer: Server,
+	config: HTTPConfig,
+): Promise<NodeServer> {
+	const app = express();
+
+	// Middleware
+	app.use(express.json());
+
+	// CORS configuration
+	if (config.corsEnabled) {
+		app.use(
+			cors({
+				origin: config.corsOrigin,
+				exposedHeaders: ["Mcp-Session-Id"],
+			}),
+		);
+	}
+
+	// Health check endpoint
+	app.get("/health", (_req: Request, res: Response) => {
+		const health: HealthCheckResponse = {
+			status: "ok",
+			timestamp: new Date().toISOString(),
+			version: "0.1.0",
+		};
+		res.json(health);
+	});
+
+	// MCP POST endpoint - handle JSON-RPC requests
+	app.post("/mcp", async (req: Request, res: Response) => {
+		const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+		logger.debug(
+			sessionId ? `Request for session: ${sessionId}` : "New request without session ID",
+			"HTTPTransport",
+		);
+
+		try {
+			let transport: StreamableHTTPServerTransport;
+
+			if (sessionId && transports.has(sessionId)) {
+				// Reuse existing transport
+				transport = transports.get(sessionId)!;
+			} else if (!sessionId && isInitializeRequest(req.body)) {
+				// New initialization request
+				const sessionIdGenerator =
+					config.sessionMode === "stateful" ? () => randomUUID() : undefined;
+
+				transport = new StreamableHTTPServerTransport({
+					sessionIdGenerator,
+					enableJsonResponse: true, // Use JSON responses instead of SSE
+					onsessioninitialized: (sid: string) => {
+						logger.debug(`Session initialized: ${sid}`, "HTTPTransport");
+						transports.set(sid, transport);
+					},
+					onsessionclosed: (sid: string) => {
+						logger.debug(`Session closed: ${sid}`, "HTTPTransport");
+						transports.delete(sid);
+					},
+				});
+
+				// Set up onclose handler
+				transport.onclose = () => {
+					const sid = transport.sessionId;
+					if (sid && transports.has(sid)) {
+						logger.debug(`Transport closed for session ${sid}`, "HTTPTransport");
+						transports.delete(sid);
+					}
+				};
+
+				// Connect transport to MCP server
+				await mcpServer.connect(transport);
+				await transport.handleRequest(req, res, req.body);
+				return;
+			} else {
+				// Invalid request
+				res.status(400).json({
+					jsonrpc: "2.0",
+					error: {
+						code: -32000,
+						message: "Bad Request: No valid session ID provided",
+					},
+					id: null,
+				});
+				return;
+			}
+
+			// Handle request with existing transport
+			await transport.handleRequest(req, res, req.body);
+		} catch (error) {
+			logger.error(
+				"Error handling MCP request",
+				"HTTPTransport",
+				error instanceof Error ? error : new Error(String(error)),
+			);
+
+			if (!res.headersSent) {
+				res.status(500).json({
+					jsonrpc: "2.0",
+					error: {
+						code: -32603,
+						message: "Internal server error",
+					},
+					id: null,
+				});
+			}
+		}
+	});
+
+	// MCP GET endpoint - SSE streams
+	app.get("/mcp", async (req: Request, res: Response) => {
+		const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+		if (!sessionId || !transports.has(sessionId)) {
+			res.status(400).send("Invalid or missing session ID");
+			return;
+		}
+
+		const lastEventId = req.headers["last-event-id"] as string | undefined;
+		if (lastEventId) {
+			logger.debug(
+				`Client reconnecting with Last-Event-ID: ${lastEventId}`,
+				"HTTPTransport",
+			);
+		} else {
+			logger.debug(`Establishing SSE stream for session ${sessionId}`, "HTTPTransport");
+		}
+
+		const transport = transports.get(sessionId)!;
+		await transport.handleRequest(req, res);
+	});
+
+	// MCP DELETE endpoint - session termination
+	app.delete("/mcp", async (req: Request, res: Response) => {
+		const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+		if (!sessionId || !transports.has(sessionId)) {
+			res.status(400).send("Invalid or missing session ID");
+			return;
+		}
+
+		logger.debug(`Session termination request for ${sessionId}`, "HTTPTransport");
+
+		try {
+			const transport = transports.get(sessionId)!;
+			await transport.handleRequest(req, res);
+		} catch (error) {
+			logger.error(
+				"Error handling session termination",
+				"HTTPTransport",
+				error instanceof Error ? error : new Error(String(error)),
+			);
+
+			if (!res.headersSent) {
+				res.status(500).send("Error processing session termination");
+			}
+		}
+	});
+
+	// Handle unsupported HTTP methods
+	app.all("/mcp", (_req: Request, res: Response) => {
+		res.status(405).json({
+			error: "Method Not Allowed",
+			message: "Only GET, POST, and DELETE methods are supported",
+		});
+	});
+
+	// Return promise that resolves when server is listening
+	return new Promise((resolve, reject) => {
+		const server = app.listen(config.port, config.host, () => {
+			logger.info(
+				`HTTP server listening on ${config.host}:${config.port}`,
+				"HTTPTransport",
+			);
+			logger.info(`Session mode: ${config.sessionMode}`, "HTTPTransport");
+			logger.info(`CORS enabled: ${config.corsEnabled}`, "HTTPTransport");
+			resolve(server);
+		});
+
+		server.on("error", (error) => {
+			logger.error(
+				"HTTP server error",
+				"HTTPTransport",
+				error instanceof Error ? error : new Error(String(error)),
+			);
+			reject(error);
+		});
+	});
+}
+
+/**
+ * Clean up all active transports and sessions
+ * Called during server shutdown
+ */
+export async function closeAllTransports(): Promise<void> {
+	logger.info(`Closing ${transports.size} active transports`, "HTTPTransport");
+
+	const closePromises: Promise<void>[] = [];
+	for (const [sessionId, transport] of transports.entries()) {
+		logger.debug(`Closing transport for session ${sessionId}`, "HTTPTransport");
+		closePromises.push(transport.close());
+	}
+
+	await Promise.all(closePromises);
+	transports.clear();
+
+	logger.info("All transports closed", "HTTPTransport");
+}

--- a/src/utils/transport-config.ts
+++ b/src/utils/transport-config.ts
@@ -1,0 +1,117 @@
+/**
+ * Transport configuration module
+ * Parses and validates environment variables for transport configuration
+ */
+
+export type TransportType = "stdio" | "http";
+export type SessionMode = "stateful" | "stateless";
+
+export interface HTTPConfig {
+	port: number;
+	host: string;
+	sessionMode: SessionMode;
+	corsEnabled: boolean;
+	corsOrigin: string;
+}
+
+export interface TransportConfig {
+	transport: TransportType;
+	http: HTTPConfig;
+}
+
+/**
+ * Parse a boolean environment variable
+ * Accepts: true, false, 1, 0 (case insensitive)
+ */
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+	if (value === undefined || value.trim() === "") {
+		return defaultValue;
+	}
+
+	const normalized = value.toLowerCase().trim();
+	if (normalized === "true" || normalized === "1") {
+		return true;
+	}
+	if (normalized === "false" || normalized === "0") {
+		return false;
+	}
+
+	throw new Error(
+		`Invalid HTTP_CORS_ENABLED value: "${value}". Expected: true, false, 1, or 0`,
+	);
+}
+
+/**
+ * Parse a port number environment variable
+ */
+function parsePort(value: string | undefined, defaultValue: number): number {
+	if (value === undefined || value.trim() === "") {
+		return defaultValue;
+	}
+
+	const port = Number.parseInt(value.trim(), 10);
+	if (Number.isNaN(port)) {
+		throw new Error(
+			`Invalid HTTP_PORT value: "${value}". Expected: number between 1 and 65535`,
+		);
+	}
+
+	if (port < 1 || port > 65535) {
+		throw new Error(`HTTP_PORT must be between 1 and 65535, got: ${port}`);
+	}
+
+	return port;
+}
+
+/**
+ * Parse transport type environment variable
+ */
+function parseTransportType(value: string | undefined): TransportType {
+	if (value === undefined || value.trim() === "") {
+		return "stdio";
+	}
+
+	const normalized = value.toLowerCase().trim() as TransportType;
+	if (normalized !== "stdio" && normalized !== "http") {
+		throw new Error(
+			`Invalid TRANSPORT value: "${value}". Expected: stdio or http`,
+		);
+	}
+
+	return normalized;
+}
+
+/**
+ * Parse session mode environment variable
+ */
+function parseSessionMode(value: string | undefined): SessionMode {
+	if (value === undefined || value.trim() === "") {
+		return "stateful";
+	}
+
+	const normalized = value.toLowerCase().trim() as SessionMode;
+	if (normalized !== "stateful" && normalized !== "stateless") {
+		throw new Error(
+			`Invalid HTTP_SESSION_MODE value: "${value}". Expected: stateful or stateless`,
+		);
+	}
+
+	return normalized;
+}
+
+/**
+ * Get transport configuration from environment variables
+ * Validates all values and provides sensible defaults
+ */
+export function getTransportConfig(): TransportConfig {
+	return {
+		transport: parseTransportType(process.env.TRANSPORT),
+		http: {
+			port: parsePort(process.env.HTTP_PORT, 3000),
+			host: process.env.HTTP_HOST?.trim() || "0.0.0.0",
+			sessionMode: parseSessionMode(process.env.HTTP_SESSION_MODE),
+			corsEnabled: parseBoolean(process.env.HTTP_CORS_ENABLED, true),
+			corsOrigin: process.env.HTTP_CORS_ORIGIN?.trim() || "*",
+		},
+	};
+}

--- a/tests/integration/http-transport.test.ts
+++ b/tests/integration/http-transport.test.ts
@@ -1,0 +1,397 @@
+import assert from "node:assert";
+import { describe, it, before, after } from "node:test";
+import type { Server as HTTPServer } from "node:http";
+
+describe("HTTP Transport Integration", () => {
+	let server: HTTPServer;
+	let baseUrl: string;
+	const TEST_PORT = 3099; // Use non-standard port for testing
+
+	before(async () => {
+		// Dynamic import to avoid loading before test setup
+		const { startHttpServer } = await import("../../src/transport/http.js");
+		const { createServer } = await import("../../src/index.js");
+
+		// Create MCP server
+		const mcpServer = createServer();
+
+		// Start HTTP server
+		server = await startHttpServer(mcpServer, {
+			port: TEST_PORT,
+			host: "127.0.0.1",
+			sessionMode: "stateful",
+			corsEnabled: true,
+			corsOrigin: "*",
+		});
+
+		baseUrl = `http://127.0.0.1:${TEST_PORT}`;
+	});
+
+	after(async () => {
+		if (server) {
+			await new Promise<void>((resolve) => {
+				server.close(() => resolve());
+			});
+		}
+	});
+
+	describe("Health Check", () => {
+		it("should respond to health check endpoint", async () => {
+			const response = await fetch(`${baseUrl}/health`);
+			assert.strictEqual(response.status, 200);
+
+			const data = await response.json();
+			assert.strictEqual(data.status, "ok");
+			assert.ok(data.timestamp);
+		});
+	});
+
+	describe("CORS Headers", () => {
+		it("should include CORS headers when enabled", async () => {
+			const response = await fetch(`${baseUrl}/health`);
+			const corsHeader = response.headers.get("access-control-allow-origin");
+			assert.strictEqual(corsHeader, "*");
+		});
+
+		it("should handle OPTIONS preflight request", async () => {
+			const response = await fetch(`${baseUrl}/mcp`, {
+				method: "OPTIONS",
+			});
+			assert.strictEqual(response.status, 204);
+		});
+	});
+
+	describe("MCP Initialization", () => {
+		it("should handle initialization request", async () => {
+			const initRequest = {
+				jsonrpc: "2.0",
+				id: 1,
+				method: "initialize",
+				params: {
+					protocolVersion: "2025-03-26",
+					capabilities: {},
+					clientInfo: {
+						name: "test-client",
+						version: "1.0.0",
+					},
+				},
+			};
+
+			const response = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Mcp-Protocol-Version": "2025-03-26",
+					Accept: "application/json, text/event-stream",
+				},
+				body: JSON.stringify(initRequest),
+			});
+
+			assert.strictEqual(response.status, 200);
+			const sessionId = response.headers.get("mcp-session-id");
+			assert.ok(sessionId, "Session ID should be present in response headers");
+
+			const data = await response.json();
+			assert.strictEqual(data.jsonrpc, "2.0");
+			assert.strictEqual(data.id, 1);
+			assert.ok(data.result);
+			assert.strictEqual(data.result.protocolVersion, "2025-03-26");
+			assert.strictEqual(data.result.serverInfo.name, "osm-tagging-schema");
+		});
+	});
+
+	describe("MCP Tool Calls", () => {
+		let sessionId: string;
+
+		before(async () => {
+			// Initialize session first
+			const initRequest = {
+				jsonrpc: "2.0",
+				id: 1,
+				method: "initialize",
+				params: {
+					protocolVersion: "2025-03-26",
+					capabilities: {},
+					clientInfo: {
+						name: "test-client",
+						version: "1.0.0",
+					},
+				},
+			};
+
+			const initResponse = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify(initRequest),
+			});
+
+			sessionId = initResponse.headers.get("mcp-session-id") || "";
+			assert.ok(sessionId);
+
+			// Send initialized notification
+			const initializedNotification = {
+				jsonrpc: "2.0",
+				method: "notifications/initialized",
+			};
+
+			await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Mcp-Session-Id": sessionId,
+				},
+				body: JSON.stringify(initializedNotification),
+			});
+		});
+
+		it("should list available tools", async () => {
+			const listToolsRequest = {
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/list",
+			};
+
+			const response = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Mcp-Session-Id": sessionId,
+				},
+				body: JSON.stringify(listToolsRequest),
+			});
+
+			assert.strictEqual(response.status, 200);
+			const data = await response.json();
+			assert.strictEqual(data.jsonrpc, "2.0");
+			assert.strictEqual(data.id, 2);
+			assert.ok(data.result);
+			assert.ok(Array.isArray(data.result.tools));
+			assert.ok(data.result.tools.length > 0);
+
+			// Check for expected tools
+			const toolNames = data.result.tools.map((t: { name: string }) => t.name);
+			assert.ok(toolNames.includes("get_schema_stats"));
+			assert.ok(toolNames.includes("get_tag_info"));
+			assert.ok(toolNames.includes("search_tags"));
+		});
+
+		it("should call get_schema_stats tool", async () => {
+			const toolCallRequest = {
+				jsonrpc: "2.0",
+				id: 3,
+				method: "tools/call",
+				params: {
+					name: "get_schema_stats",
+					arguments: {},
+				},
+			};
+
+			const response = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Mcp-Session-Id": sessionId,
+				},
+				body: JSON.stringify(toolCallRequest),
+			});
+
+			assert.strictEqual(response.status, 200);
+			const data = await response.json();
+			assert.strictEqual(data.jsonrpc, "2.0");
+			assert.strictEqual(data.id, 3);
+			assert.ok(data.result);
+			assert.ok(Array.isArray(data.result.content));
+			assert.ok(data.result.content.length > 0);
+
+			const content = JSON.parse(data.result.content[0].text);
+			assert.ok(content.presets);
+			assert.ok(content.fields);
+			assert.ok(content.categories);
+		});
+
+		it("should handle invalid session ID", async () => {
+			const toolCallRequest = {
+				jsonrpc: "2.0",
+				id: 4,
+				method: "tools/call",
+				params: {
+					name: "get_schema_stats",
+					arguments: {},
+				},
+			};
+
+			const response = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Mcp-Session-Id": "invalid-session-id",
+				},
+				body: JSON.stringify(toolCallRequest),
+			});
+
+			assert.strictEqual(response.status, 404);
+		});
+
+		it("should handle missing session ID for non-init request", async () => {
+			const toolCallRequest = {
+				jsonrpc: "2.0",
+				id: 5,
+				method: "tools/call",
+				params: {
+					name: "get_schema_stats",
+					arguments: {},
+				},
+			};
+
+			const response = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify(toolCallRequest),
+			});
+
+			assert.strictEqual(response.status, 400);
+		});
+	});
+
+	describe("Session Management", () => {
+		it("should maintain separate sessions for multiple clients", async () => {
+			// Initialize first session
+			const initRequest1 = {
+				jsonrpc: "2.0",
+				id: 1,
+				method: "initialize",
+				params: {
+					protocolVersion: "2025-03-26",
+					capabilities: {},
+					clientInfo: {
+						name: "test-client-1",
+						version: "1.0.0",
+					},
+				},
+			};
+
+			const response1 = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify(initRequest1),
+			});
+
+			const sessionId1 = response1.headers.get("mcp-session-id");
+			assert.ok(sessionId1);
+
+			// Initialize second session
+			const initRequest2 = {
+				jsonrpc: "2.0",
+				id: 1,
+				method: "initialize",
+				params: {
+					protocolVersion: "2025-03-26",
+					capabilities: {},
+					clientInfo: {
+						name: "test-client-2",
+						version: "1.0.0",
+					},
+				},
+			};
+
+			const response2 = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify(initRequest2),
+			});
+
+			const sessionId2 = response2.headers.get("mcp-session-id");
+			assert.ok(sessionId2);
+
+			// Sessions should be different
+			assert.notStrictEqual(sessionId1, sessionId2);
+		});
+
+		it("should handle session termination via DELETE", async () => {
+			// Initialize session
+			const initRequest = {
+				jsonrpc: "2.0",
+				id: 1,
+				method: "initialize",
+				params: {
+					protocolVersion: "2025-03-26",
+					capabilities: {},
+					clientInfo: {
+						name: "test-client",
+						version: "1.0.0",
+					},
+				},
+			};
+
+			const initResponse = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify(initRequest),
+			});
+
+			const sessionId = initResponse.headers.get("mcp-session-id");
+			assert.ok(sessionId);
+
+			// Terminate session
+			const deleteResponse = await fetch(`${baseUrl}/mcp`, {
+				method: "DELETE",
+				headers: {
+					"Mcp-Session-Id": sessionId,
+				},
+			});
+
+			assert.strictEqual(deleteResponse.status, 200);
+
+			// Try to use terminated session
+			const toolCallRequest = {
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/list",
+			};
+
+			const response = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Mcp-Session-Id": sessionId,
+				},
+				body: JSON.stringify(toolCallRequest),
+			});
+
+			// Should fail with 404 after session termination
+			assert.strictEqual(response.status, 404);
+		});
+	});
+
+	describe("Error Handling", () => {
+		it("should handle malformed JSON", async () => {
+			const response = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: "invalid json{",
+			});
+
+			assert.strictEqual(response.status, 400);
+		});
+
+		it("should handle unsupported HTTP methods", async () => {
+			const response = await fetch(`${baseUrl}/mcp`, {
+				method: "PUT",
+			});
+
+			assert.strictEqual(response.status, 405);
+		});
+	});
+});

--- a/tests/utils/transport-config.test.ts
+++ b/tests/utils/transport-config.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { getTransportConfig, type TransportConfig } from "../../src/utils/transport-config.js";
+
+describe("Transport Configuration", () => {
+	let originalEnv: NodeJS.ProcessEnv;
+
+	beforeEach(() => {
+		// Save original environment
+		originalEnv = { ...process.env };
+	});
+
+	afterEach(() => {
+		// Restore original environment
+		process.env = originalEnv;
+	});
+
+	describe("Default Configuration", () => {
+		it("should return stdio as default transport", () => {
+			delete process.env.TRANSPORT;
+			const config = getTransportConfig();
+			assert.strictEqual(config.transport, "stdio");
+		});
+
+		it("should return default HTTP configuration", () => {
+			delete process.env.TRANSPORT;
+			delete process.env.HTTP_PORT;
+			delete process.env.HTTP_HOST;
+			delete process.env.HTTP_SESSION_MODE;
+			delete process.env.HTTP_CORS_ENABLED;
+			delete process.env.HTTP_CORS_ORIGIN;
+
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.port, 3000);
+			assert.strictEqual(config.http.host, "0.0.0.0");
+			assert.strictEqual(config.http.sessionMode, "stateful");
+			assert.strictEqual(config.http.corsEnabled, true);
+			assert.strictEqual(config.http.corsOrigin, "*");
+		});
+	});
+
+	describe("Environment Variable Parsing", () => {
+		it("should parse TRANSPORT=stdio", () => {
+			process.env.TRANSPORT = "stdio";
+			const config = getTransportConfig();
+			assert.strictEqual(config.transport, "stdio");
+		});
+
+		it("should parse TRANSPORT=http", () => {
+			process.env.TRANSPORT = "http";
+			const config = getTransportConfig();
+			assert.strictEqual(config.transport, "http");
+		});
+
+		it("should throw error for invalid transport", () => {
+			process.env.TRANSPORT = "invalid";
+			assert.throws(
+				() => getTransportConfig(),
+				/Invalid TRANSPORT value/,
+			);
+		});
+
+		it("should parse HTTP_PORT as number", () => {
+			process.env.HTTP_PORT = "8080";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.port, 8080);
+			assert.strictEqual(typeof config.http.port, "number");
+		});
+
+		it("should throw error for invalid HTTP_PORT", () => {
+			process.env.HTTP_PORT = "invalid";
+			assert.throws(
+				() => getTransportConfig(),
+				/Invalid HTTP_PORT value/,
+			);
+		});
+
+		it("should throw error for HTTP_PORT out of range (low)", () => {
+			process.env.HTTP_PORT = "0";
+			assert.throws(
+				() => getTransportConfig(),
+				/HTTP_PORT must be between 1 and 65535/,
+			);
+		});
+
+		it("should throw error for HTTP_PORT out of range (high)", () => {
+			process.env.HTTP_PORT = "70000";
+			assert.throws(
+				() => getTransportConfig(),
+				/HTTP_PORT must be between 1 and 65535/,
+			);
+		});
+
+		it("should parse HTTP_HOST", () => {
+			process.env.HTTP_HOST = "127.0.0.1";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.host, "127.0.0.1");
+		});
+
+		it("should parse HTTP_SESSION_MODE=stateful", () => {
+			process.env.HTTP_SESSION_MODE = "stateful";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.sessionMode, "stateful");
+		});
+
+		it("should parse HTTP_SESSION_MODE=stateless", () => {
+			process.env.HTTP_SESSION_MODE = "stateless";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.sessionMode, "stateless");
+		});
+
+		it("should throw error for invalid HTTP_SESSION_MODE", () => {
+			process.env.HTTP_SESSION_MODE = "invalid";
+			assert.throws(
+				() => getTransportConfig(),
+				/Invalid HTTP_SESSION_MODE value/,
+			);
+		});
+
+		it("should parse HTTP_CORS_ENABLED=true", () => {
+			process.env.HTTP_CORS_ENABLED = "true";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.corsEnabled, true);
+		});
+
+		it("should parse HTTP_CORS_ENABLED=false", () => {
+			process.env.HTTP_CORS_ENABLED = "false";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.corsEnabled, false);
+		});
+
+		it("should parse HTTP_CORS_ENABLED=1 as true", () => {
+			process.env.HTTP_CORS_ENABLED = "1";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.corsEnabled, true);
+		});
+
+		it("should parse HTTP_CORS_ENABLED=0 as false", () => {
+			process.env.HTTP_CORS_ENABLED = "0";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.corsEnabled, false);
+		});
+
+		it("should throw error for invalid HTTP_CORS_ENABLED", () => {
+			process.env.HTTP_CORS_ENABLED = "invalid";
+			assert.throws(
+				() => getTransportConfig(),
+				/Invalid HTTP_CORS_ENABLED value/,
+			);
+		});
+
+		it("should parse HTTP_CORS_ORIGIN", () => {
+			process.env.HTTP_CORS_ORIGIN = "https://example.com";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.corsOrigin, "https://example.com");
+		});
+	});
+
+	describe("Full Configuration", () => {
+		it("should parse all HTTP environment variables together", () => {
+			process.env.TRANSPORT = "http";
+			process.env.HTTP_PORT = "8080";
+			process.env.HTTP_HOST = "localhost";
+			process.env.HTTP_SESSION_MODE = "stateless";
+			process.env.HTTP_CORS_ENABLED = "false";
+			process.env.HTTP_CORS_ORIGIN = "https://example.com";
+
+			const config = getTransportConfig();
+			assert.strictEqual(config.transport, "http");
+			assert.strictEqual(config.http.port, 8080);
+			assert.strictEqual(config.http.host, "localhost");
+			assert.strictEqual(config.http.sessionMode, "stateless");
+			assert.strictEqual(config.http.corsEnabled, false);
+			assert.strictEqual(config.http.corsOrigin, "https://example.com");
+		});
+	});
+
+	describe("Type Safety", () => {
+		it("should return TransportConfig type", () => {
+			const config = getTransportConfig();
+			// Type assertions - will fail at compile time if types are wrong
+			const transport: "stdio" | "http" = config.transport;
+			const port: number = config.http.port;
+			const host: string = config.http.host;
+			const sessionMode: "stateful" | "stateless" = config.http.sessionMode;
+			const corsEnabled: boolean = config.http.corsEnabled;
+			const corsOrigin: string = config.http.corsOrigin;
+
+			assert.ok(transport !== undefined);
+			assert.ok(typeof port === "number");
+			assert.ok(typeof host === "string");
+			assert.ok(sessionMode !== undefined);
+			assert.ok(typeof corsEnabled === "boolean");
+			assert.ok(typeof corsOrigin === "string");
+		});
+	});
+
+	describe("Case Insensitivity", () => {
+		it("should handle TRANSPORT in uppercase", () => {
+			process.env.TRANSPORT = "HTTP";
+			const config = getTransportConfig();
+			assert.strictEqual(config.transport, "http");
+		});
+
+		it("should handle TRANSPORT in mixed case", () => {
+			process.env.TRANSPORT = "StDiO";
+			const config = getTransportConfig();
+			assert.strictEqual(config.transport, "stdio");
+		});
+
+		it("should handle HTTP_SESSION_MODE in uppercase", () => {
+			process.env.HTTP_SESSION_MODE = "STATEFUL";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.sessionMode, "stateful");
+		});
+
+		it("should handle HTTP_CORS_ENABLED in uppercase", () => {
+			process.env.HTTP_CORS_ENABLED = "TRUE";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.corsEnabled, true);
+		});
+	});
+
+	describe("Edge Cases", () => {
+		it("should handle empty string for TRANSPORT (use default)", () => {
+			process.env.TRANSPORT = "";
+			const config = getTransportConfig();
+			assert.strictEqual(config.transport, "stdio");
+		});
+
+		it("should handle whitespace in TRANSPORT", () => {
+			process.env.TRANSPORT = "  http  ";
+			const config = getTransportConfig();
+			assert.strictEqual(config.transport, "http");
+		});
+
+		it("should handle minimum valid port (1)", () => {
+			process.env.HTTP_PORT = "1";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.port, 1);
+		});
+
+		it("should handle maximum valid port (65535)", () => {
+			process.env.HTTP_PORT = "65535";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.port, 65535);
+		});
+
+		it("should handle IPv6 host", () => {
+			process.env.HTTP_HOST = "::1";
+			const config = getTransportConfig();
+			assert.strictEqual(config.http.host, "::1");
+		});
+	});
+});


### PR DESCRIPTION
…witching

Add HTTP transport support with SSE (Server-Sent Events) alongside existing stdio transport. Transport is switchable via TRANSPORT environment variable.

New Features:
- Environment-based transport configuration (stdio/http)
- HTTP server with Express.js and CORS support
- Streamable HTTP transport using MCP SDK
- Session management (stateful/stateless modes)
- Health check endpoint
- Graceful shutdown handling

Configuration (Environment Variables):
- TRANSPORT: stdio (default) or http
- HTTP_PORT: Server port (default: 3000)
- HTTP_HOST: Server host (default: 0.0.0.0)
- HTTP_SESSION_MODE: stateful or stateless (default: stateful)
- HTTP_CORS_ENABLED: Enable CORS (default: true)
- HTTP_CORS_ORIGIN: CORS origin (default: *)

New Files:
- src/utils/transport-config.ts: Configuration parser with validation
- src/transport/http.ts: HTTP transport implementation
- tests/utils/transport-config.test.ts: 30 unit tests for config (100% pass)
- tests/integration/http-transport.test.ts: Integration tests for HTTP transport
- docs/http-transport.md: Complete HTTP transport documentation

Updated Files:
- src/index.ts: Multi-transport support with auto-detection
- README.md: HTTP transport quick start section
- package.json: Added express, cors dependencies
- package-lock.json: Dependency lock file update

Endpoints:
- GET /health: Health check with status and version
- POST /mcp: MCP JSON-RPC requests
- GET /mcp: SSE stream for server notifications
- DELETE /mcp: Session termination

Testing:
- 30 new unit tests for transport configuration (all passing)
- Integration tests for HTTP transport
- 335/341 unit tests passing overall
- Type checking and linting pass

Documentation:
- Complete HTTP transport guide with examples
- Configuration reference
- JavaScript/TypeScript integration examples
- Python integration examples
- Security considerations

Usage:
  TRANSPORT=http npm start TRANSPORT=http HTTP_PORT=8080 npm start docker run -e TRANSPORT=http -p 3000:3000 ghcr.io/gander-tools/osm-tagging-schema-mcp:dev