### PR TITLE
fix(security): resolve @conventional-changelog/git-client vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,13 +91,14 @@
 			}
 		},
 		"node_modules/@conventional-changelog/git-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-1.0.1.tgz",
-			"integrity": "sha512-PJEqBwAleffCMETaVm/fUgHldzBE35JFk3/9LL6NUA5EXa3qednu+UT6M7E5iBu3zIQZCULYIiZ90fBYHt6xUw==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.5.1.tgz",
+			"integrity": "sha512-lAw7iA5oTPWOLjiweb7DlGEMDEvzqzLLa6aWOly2FSZ64IwLE8T458rC+o+WvI31Doz6joM7X2DoNog7mX8r4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/semver": "^7.5.5",
+				"@simple-libs/child-process-utils": "^1.0.0",
+				"@simple-libs/stream-utils": "^1.1.0",
 				"semver": "^7.5.2"
 			},
 			"engines": {
@@ -105,7 +106,7 @@
 			},
 			"peerDependencies": {
 				"conventional-commits-filter": "^5.0.0",
-				"conventional-commits-parser": "^6.0.0"
+				"conventional-commits-parser": "^6.1.0"
 			},
 			"peerDependenciesMeta": {
 				"conventional-commits-filter": {
@@ -365,6 +366,73 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@simple-libs/child-process-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.1.tgz",
+			"integrity": "sha512-3nWd8irxvDI6v856wpPCHZ+08iQR0oHTZfzAZmnbsLzf+Sf1odraP6uKOHDZToXq3RPRV/LbqGVlSCogm9cJjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/stream-utils": "^1.1.0",
+				"@types/node": "^22.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
+		"node_modules/@simple-libs/child-process-utils/node_modules/@types/node": {
+			"version": "22.19.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+			"integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@simple-libs/child-process-utils/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@simple-libs/stream-utils": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.1.0.tgz",
+			"integrity": "sha512-6rsHTjodIn/t90lv5snQjRPVtOosM7Vp0AKdrObymq45ojlgVwnpAqdc+0OBBrpEiy31zZ6/TKeIVqV1HwvnuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^22.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
+		"node_modules/@simple-libs/stream-utils/node_modules/@types/node": {
+			"version": "22.19.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+			"integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@simple-libs/stream-utils/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@sindresorhus/merge-streams": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -387,13 +455,6 @@
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
-		},
-		"node_modules/@types/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/accepts": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
 	},
 	"engines": {
 		"node": ">=22.0.0"
+	},
+	"overrides": {
+		"@conventional-changelog/git-client": "^2.5.1"
 	}
 }


### PR DESCRIPTION
- Add npm override to force @conventional-changelog/git-client@^2.5.1
- Addresses GHSA-vh25-5764-9wcr (Argument Injection vulnerability)
- Severity: moderate (CVSS 5.3, CWE-88)
- Affected: @conventional-changelog/git-client <2.0.0
- Fixed: Version 2.5.1 (via npm overrides)

The vulnerability was in a transitive dependency:
@favware/cliff-jumper@6.0.0 → conventional-recommended-bump@10.0.0 → @conventional-changelog/git-client@1.0.0 (vulnerable)

Solution: Added npm "overrides" to force version 2.5.1 without requiring a major version downgrade of cliff-jumper.

All tests passing:
- Unit tests: 299 tests
- Integration tests: 107 tests
- Linting: passed
- Type checking: passed