### PR TITLE
refactor: remove schemaLoader parameter from tool handlers

### DIFF
--- a/src/tools/check-deprecated.ts
+++ b/src/tools/check-deprecated.ts
@@ -2,6 +2,7 @@ import deprecated from "@openstreetmap/id-tagging-schema/dist/deprecated.json" w
 	type: "json",
 };
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 
 /**
  * Tool definition for check_deprecated
@@ -144,12 +145,12 @@ export async function checkDeprecated(
 /**
  * Handler for check_deprecated tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { key, value } = args as { key?: string; value?: string };
 	if (key === undefined) {
 		throw new Error("key parameter is required");
 	}
-	const result = await checkDeprecated(loader, key, value);
+	const result = await checkDeprecated(schemaLoader, key, value);
 	return {
 		content: [
 			{

--- a/src/tools/get-categories.ts
+++ b/src/tools/get-categories.ts
@@ -1,4 +1,5 @@
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { CategoryInfo } from "./types.js";
 
 /**
@@ -37,8 +38,8 @@ export async function getCategories(loader: SchemaLoader): Promise<CategoryInfo[
 /**
  * Handler for get_categories tool
  */
-export async function handler(loader: SchemaLoader, _args: unknown) {
-	const categories = await getCategories(loader);
+export async function handler(_args: unknown) {
+	const categories = await getCategories(schemaLoader);
 	return {
 		content: [
 			{

--- a/src/tools/get-category-tags.ts
+++ b/src/tools/get-category-tags.ts
@@ -1,4 +1,5 @@
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 
 /**
  * Tool definition for get_category_tags
@@ -41,12 +42,12 @@ export async function getCategoryTags(
 /**
  * Handler for get_category_tags tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const category = (args as { category?: string }).category;
 	if (!category) {
 		throw new Error("category parameter is required");
 	}
-	const tags = await getCategoryTags(loader, category);
+	const tags = await getCategoryTags(schemaLoader, category);
 	return {
 		content: [
 			{

--- a/src/tools/get-preset-details.ts
+++ b/src/tools/get-preset-details.ts
@@ -1,4 +1,5 @@
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { PresetDetails } from "./types.js";
 
 /**
@@ -71,12 +72,12 @@ export async function getPresetDetails(
 /**
  * Handler for get_preset_details tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const presetId = (args as { presetId?: string }).presetId;
 	if (!presetId) {
 		throw new Error("presetId parameter is required");
 	}
-	const details = await getPresetDetails(loader, presetId);
+	const details = await getPresetDetails(schemaLoader, presetId);
 	return {
 		content: [
 			{

--- a/src/tools/get-preset-tags.ts
+++ b/src/tools/get-preset-tags.ts
@@ -1,4 +1,5 @@
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { PresetTags } from "./types.js";
 
 /**
@@ -54,12 +55,12 @@ export async function getPresetTags(loader: SchemaLoader, presetId: string): Pro
 /**
  * Handler for get_preset_tags tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const presetId = (args as { presetId?: string }).presetId;
 	if (!presetId) {
 		throw new Error("presetId parameter is required");
 	}
-	const tags = await getPresetTags(loader, presetId);
+	const tags = await getPresetTags(schemaLoader, presetId);
 	return {
 		content: [
 			{

--- a/src/tools/get-related-tags.ts
+++ b/src/tools/get-related-tags.ts
@@ -1,4 +1,5 @@
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { RelatedTag } from "./types.js";
 
 /**
@@ -128,12 +129,12 @@ export async function getRelatedTags(
 /**
  * Handler for get_related_tags tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { tag, limit } = args as { tag?: string; limit?: number };
 	if (!tag) {
 		throw new Error("tag parameter is required");
 	}
-	const results = await getRelatedTags(loader, tag, limit);
+	const results = await getRelatedTags(schemaLoader, tag, limit);
 	return {
 		content: [
 			{

--- a/src/tools/get-schema-stats.ts
+++ b/src/tools/get-schema-stats.ts
@@ -1,4 +1,5 @@
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { SchemaStats } from "./types.js";
 
 /**
@@ -37,8 +38,8 @@ export async function getSchemaStats(loader: SchemaLoader): Promise<SchemaStats>
 /**
  * Handler for get_schema_stats tool
  */
-export async function handler(loader: SchemaLoader, _args: unknown) {
-	const stats = await getSchemaStats(loader);
+export async function handler(_args: unknown) {
+	const stats = await getSchemaStats(schemaLoader);
 	return {
 		content: [
 			{

--- a/src/tools/get-tag-info.ts
+++ b/src/tools/get-tag-info.ts
@@ -1,4 +1,5 @@
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { TagInfo } from "./types.js";
 
 /**
@@ -90,12 +91,12 @@ export async function getTagInfo(loader: SchemaLoader, tagKey: string): Promise<
 /**
  * Handler for get_tag_info tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const tagKey = (args as { tagKey?: string }).tagKey;
 	if (!tagKey) {
 		throw new Error("tagKey parameter is required");
 	}
-	const info = await getTagInfo(loader, tagKey);
+	const info = await getTagInfo(schemaLoader, tagKey);
 	return {
 		content: [
 			{

--- a/src/tools/get-tag-values.ts
+++ b/src/tools/get-tag-values.ts
@@ -1,4 +1,5 @@
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 
 /**
  * Tool definition for get_tag_values
@@ -79,12 +80,12 @@ export async function getTagValues(loader: SchemaLoader, tagKey: string): Promis
 /**
  * Handler for get_tag_values tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const tagKey = (args as { tagKey?: string }).tagKey;
 	if (!tagKey) {
 		throw new Error("tagKey parameter is required");
 	}
-	const values = await getTagValues(loader, tagKey);
+	const values = await getTagValues(schemaLoader, tagKey);
 	return {
 		content: [
 			{

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,7 +2,6 @@
  * Tool registry - exports all tools with their definitions and handlers
  */
 
-import type { SchemaLoader } from "../utils/schema-loader.js";
 import * as checkDeprecated from "./check-deprecated.js";
 import * as getCategories from "./get-categories.js";
 import * as getCategoryTags from "./get-category-tags.js";
@@ -34,10 +33,7 @@ export interface ToolDefinition {
 /**
  * Tool handler function signature
  */
-export type ToolHandler = (
-	loader: SchemaLoader,
-	args: unknown,
-) => Promise<{
+export type ToolHandler = (args: unknown) => Promise<{
 	content: Array<{ type: "text"; text: string }>;
 }>;
 

--- a/src/tools/search-presets.ts
+++ b/src/tools/search-presets.ts
@@ -1,5 +1,6 @@
 import type { GeometryType } from "../types/index.js";
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { PresetSearchResult } from "./types.js";
 
 /**
@@ -128,7 +129,7 @@ export async function searchPresets(
 /**
  * Handler for search_presets tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { keyword, limit, geometry } = args as {
 		keyword?: string;
 		limit?: number;
@@ -137,7 +138,7 @@ export async function handler(loader: SchemaLoader, args: unknown) {
 	if (!keyword) {
 		throw new Error("keyword parameter is required");
 	}
-	const results = await searchPresets(loader, keyword, { limit, geometry });
+	const results = await searchPresets(schemaLoader, keyword, { limit, geometry });
 	return {
 		content: [
 			{

--- a/src/tools/search-tags.ts
+++ b/src/tools/search-tags.ts
@@ -1,4 +1,5 @@
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { TagSearchResult } from "./types.js";
 
 /**
@@ -144,12 +145,12 @@ export async function searchTags(
 /**
  * Handler for search_tags tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { keyword, limit } = args as { keyword?: string; limit?: number };
 	if (!keyword) {
 		throw new Error("keyword parameter is required");
 	}
-	const results = await searchTags(loader, keyword, limit);
+	const results = await searchTags(schemaLoader, keyword, limit);
 	return {
 		content: [
 			{

--- a/src/tools/suggest-improvements.ts
+++ b/src/tools/suggest-improvements.ts
@@ -1,6 +1,7 @@
 import fields from "@openstreetmap/id-tagging-schema/dist/fields.json" with { type: "json" };
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import { checkDeprecated } from "./check-deprecated.js";
 
 /**
@@ -181,12 +182,12 @@ function getFieldKey(fieldId: string): string | null {
 /**
  * Handler for suggest_improvements tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { tags } = args as { tags?: Record<string, string> };
 	if (!tags) {
 		throw new Error("tags parameter is required");
 	}
-	const result = await suggestImprovements(loader, tags);
+	const result = await suggestImprovements(schemaLoader, tags);
 	return {
 		content: [
 			{

--- a/src/tools/validate-tag-collection.ts
+++ b/src/tools/validate-tag-collection.ts
@@ -1,4 +1,5 @@
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import { type ValidationResult, validateTag } from "./validate-tag.js";
 
 /**
@@ -95,12 +96,12 @@ export async function validateTagCollection(
 /**
  * Handler for validate_tag_collection tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { tags } = args as { tags?: Record<string, string> };
 	if (!tags) {
 		throw new Error("tags parameter is required");
 	}
-	const result = await validateTagCollection(loader, tags);
+	const result = await validateTagCollection(schemaLoader, tags);
 	return {
 		content: [
 			{

--- a/src/tools/validate-tag.ts
+++ b/src/tools/validate-tag.ts
@@ -3,6 +3,7 @@ import deprecated from "@openstreetmap/id-tagging-schema/dist/deprecated.json" w
 };
 import fields from "@openstreetmap/id-tagging-schema/dist/fields.json" with { type: "json" };
 import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 
 /**
  * Tool definition for validate_tag
@@ -150,7 +151,7 @@ export async function validateTag(
 /**
  * Handler for validate_tag tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { key, value } = args as { key?: string; value?: string };
 	if (key === undefined) {
 		throw new Error("key parameter is required");
@@ -158,7 +159,7 @@ export async function handler(loader: SchemaLoader, args: unknown) {
 	if (value === undefined) {
 		throw new Error("value parameter is required");
 	}
-	const result = await validateTag(loader, key, value);
+	const result = await validateTag(schemaLoader, key, value);
 	return {
 		content: [
 			{

--- a/src/utils/schema-loader.ts
+++ b/src/utils/schema-loader.ts
@@ -400,3 +400,9 @@ export class SchemaLoader {
 		logger.debug("Schema structure validation passed", "SchemaLoader");
 	}
 }
+
+/**
+ * Singleton instance of SchemaLoader for use across the application
+ * Import this instance in tool handlers instead of receiving it as a parameter
+ */
+export const schemaLoader = new SchemaLoader();


### PR DESCRIPTION
Changed handler signature from higher-order function pattern to direct async functions that use a singleton schemaLoader instance. This simplifies the handler architecture and removes unnecessary parameter passing.

Changes:
- Added singleton schemaLoader export in schema-loader.ts
- Updated ToolHandler type to remove loader parameter
- Modified all 14 tool handlers to use singleton schemaLoader
- Updated src/index.ts to not pass schemaLoader to handlers
- Removed local SchemaLoader instantiation from createServer() and main()

All tests passing (313 unit + 120 integration).