### PR TITLE
Remove SchemaLoader from handler arguments

### DIFF
--- a/src/tools/check-deprecated.ts
+++ b/src/tools/check-deprecated.ts
@@ -1,7 +1,6 @@
 import deprecated from "@openstreetmap/id-tagging-schema/dist/deprecated.json" with {
 	type: "json",
 };
-import type { SchemaLoader } from "../utils/schema-loader.js";
 
 /**
  * Tool definition for check_deprecated
@@ -43,16 +42,11 @@ export interface DeprecationResult {
 /**
  * Check if an OSM tag is deprecated
  *
- * @param _loader - Schema loader instance (reserved for future use)
  * @param key - Tag key to check
  * @param value - Optional tag value. If not provided, checks if any value for this key is deprecated
  * @returns Deprecation result with replacement suggestions
  */
-export async function checkDeprecated(
-	_loader: SchemaLoader,
-	key: string,
-	value?: string,
-): Promise<DeprecationResult> {
+export async function checkDeprecated(key: string, value?: string): Promise<DeprecationResult> {
 	// Handle empty key
 	if (!key || key.trim() === "") {
 		return {
@@ -144,12 +138,12 @@ export async function checkDeprecated(
 /**
  * Handler for check_deprecated tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { key, value } = args as { key?: string; value?: string };
 	if (key === undefined) {
 		throw new Error("key parameter is required");
 	}
-	const result = await checkDeprecated(loader, key, value);
+	const result = await checkDeprecated(key, value);
 	return {
 		content: [
 			{

--- a/src/tools/get-categories.ts
+++ b/src/tools/get-categories.ts
@@ -1,4 +1,4 @@
-import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { CategoryInfo } from "./types.js";
 
 /**
@@ -18,11 +18,10 @@ export const definition = {
 /**
  * Get all tag categories with counts of presets in each category
  *
- * @param loader - Schema loader instance
  * @returns Array of categories sorted by name, each with name and preset count
  */
-export async function getCategories(loader: SchemaLoader): Promise<CategoryInfo[]> {
-	const schema = await loader.loadSchema();
+export async function getCategories(): Promise<CategoryInfo[]> {
+	const schema = await schemaLoader.loadSchema();
 
 	// Create array of categories with counts
 	const categories: CategoryInfo[] = Object.entries(schema.categories).map(([name, category]) => ({
@@ -37,8 +36,8 @@ export async function getCategories(loader: SchemaLoader): Promise<CategoryInfo[
 /**
  * Handler for get_categories tool
  */
-export async function handler(loader: SchemaLoader, _args: unknown) {
-	const categories = await getCategories(loader);
+export async function handler(_args: unknown) {
+	const categories = await getCategories();
 	return {
 		content: [
 			{

--- a/src/tools/get-category-tags.ts
+++ b/src/tools/get-category-tags.ts
@@ -1,4 +1,4 @@
-import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 
 /**
  * Tool definition for get_category_tags
@@ -21,15 +21,11 @@ export const definition = {
 /**
  * Get all tags (preset IDs) belonging to a specific category
  *
- * @param loader - Schema loader instance
  * @param categoryName - Name of the category
  * @returns Array of preset IDs belonging to the category
  */
-export async function getCategoryTags(
-	loader: SchemaLoader,
-	categoryName: string,
-): Promise<string[]> {
-	const schema = await loader.loadSchema();
+export async function getCategoryTags(categoryName: string): Promise<string[]> {
+	const schema = await schemaLoader.loadSchema();
 
 	// Get the category
 	const category = schema.categories[categoryName];
@@ -41,12 +37,12 @@ export async function getCategoryTags(
 /**
  * Handler for get_category_tags tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const category = (args as { category?: string }).category;
 	if (!category) {
 		throw new Error("category parameter is required");
 	}
-	const tags = await getCategoryTags(loader, category);
+	const tags = await getCategoryTags(category);
 	return {
 		content: [
 			{

--- a/src/tools/get-preset-details.ts
+++ b/src/tools/get-preset-details.ts
@@ -1,4 +1,4 @@
-import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { PresetDetails } from "./types.js";
 
 /**
@@ -23,16 +23,12 @@ export const definition = {
 /**
  * Get complete details for a specific preset
  *
- * @param loader - Schema loader instance
  * @param presetId - The preset ID to get details for (e.g., "amenity/restaurant")
  * @returns Complete preset details including tags, geometry, fields, and metadata
  * @throws Error if preset is not found
  */
-export async function getPresetDetails(
-	loader: SchemaLoader,
-	presetId: string,
-): Promise<PresetDetails> {
-	const schema = await loader.loadSchema();
+export async function getPresetDetails(presetId: string): Promise<PresetDetails> {
+	const schema = await schemaLoader.loadSchema();
 
 	// Look up the preset
 	const preset = schema.presets[presetId];
@@ -71,12 +67,12 @@ export async function getPresetDetails(
 /**
  * Handler for get_preset_details tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const presetId = (args as { presetId?: string }).presetId;
 	if (!presetId) {
 		throw new Error("presetId parameter is required");
 	}
-	const details = await getPresetDetails(loader, presetId);
+	const details = await getPresetDetails(presetId);
 	return {
 		content: [
 			{

--- a/src/tools/get-preset-tags.ts
+++ b/src/tools/get-preset-tags.ts
@@ -1,4 +1,4 @@
-import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { PresetTags } from "./types.js";
 
 /**
@@ -23,13 +23,12 @@ export const definition = {
 /**
  * Get recommended tags for a specific preset
  *
- * @param loader - Schema loader instance
  * @param presetId - The preset ID to get tags for (e.g., "amenity/restaurant")
  * @returns Preset tags including identifying tags and optional addTags
  * @throws Error if preset is not found
  */
-export async function getPresetTags(loader: SchemaLoader, presetId: string): Promise<PresetTags> {
-	const schema = await loader.loadSchema();
+export async function getPresetTags(presetId: string): Promise<PresetTags> {
+	const schema = await schemaLoader.loadSchema();
 
 	// Look up the preset
 	const preset = schema.presets[presetId];
@@ -54,12 +53,12 @@ export async function getPresetTags(loader: SchemaLoader, presetId: string): Pro
 /**
  * Handler for get_preset_tags tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const presetId = (args as { presetId?: string }).presetId;
 	if (!presetId) {
 		throw new Error("presetId parameter is required");
 	}
-	const tags = await getPresetTags(loader, presetId);
+	const tags = await getPresetTags(presetId);
 	return {
 		content: [
 			{

--- a/src/tools/get-related-tags.ts
+++ b/src/tools/get-related-tags.ts
@@ -1,4 +1,4 @@
-import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { RelatedTag } from "./types.js";
 
 /**
@@ -28,17 +28,12 @@ export const definition = {
 /**
  * Find tags commonly used together with a given tag
  *
- * @param loader - Schema loader instance
  * @param tag - Tag to find related tags for (format: "key" or "key=value")
  * @param limit - Maximum number of results to return (optional)
  * @returns Array of related tags sorted by frequency (descending)
  */
-export async function getRelatedTags(
-	loader: SchemaLoader,
-	tag: string,
-	limit?: number,
-): Promise<RelatedTag[]> {
-	const schema = await loader.loadSchema();
+export async function getRelatedTags(tag: string, limit?: number): Promise<RelatedTag[]> {
+	const schema = await schemaLoader.loadSchema();
 
 	// Parse the input tag
 	const [inputKey, inputValue] = tag.includes("=") ? tag.split("=", 2) : [tag, undefined];
@@ -128,12 +123,12 @@ export async function getRelatedTags(
 /**
  * Handler for get_related_tags tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { tag, limit } = args as { tag?: string; limit?: number };
 	if (!tag) {
 		throw new Error("tag parameter is required");
 	}
-	const results = await getRelatedTags(loader, tag, limit);
+	const results = await getRelatedTags(tag, limit);
 	return {
 		content: [
 			{

--- a/src/tools/get-schema-stats.ts
+++ b/src/tools/get-schema-stats.ts
@@ -1,4 +1,4 @@
-import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { SchemaStats } from "./types.js";
 
 /**
@@ -18,11 +18,10 @@ export const definition = {
 /**
  * Get statistics about the OSM tagging schema
  *
- * @param loader - Schema loader instance
  * @returns Schema statistics including counts of presets, fields, categories, deprecated items, and version info
  */
-export async function getSchemaStats(loader: SchemaLoader): Promise<SchemaStats> {
-	const schema = await loader.loadSchema();
+export async function getSchemaStats(): Promise<SchemaStats> {
+	const schema = await schemaLoader.loadSchema();
 
 	return {
 		presetCount: Object.keys(schema.presets).length,
@@ -37,8 +36,8 @@ export async function getSchemaStats(loader: SchemaLoader): Promise<SchemaStats>
 /**
  * Handler for get_schema_stats tool
  */
-export async function handler(loader: SchemaLoader, _args: unknown) {
-	const stats = await getSchemaStats(loader);
+export async function handler(_args: unknown) {
+	const stats = await getSchemaStats();
 	return {
 		content: [
 			{

--- a/src/tools/get-tag-info.ts
+++ b/src/tools/get-tag-info.ts
@@ -1,4 +1,4 @@
-import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { TagInfo } from "./types.js";
 
 /**
@@ -23,12 +23,11 @@ export const definition = {
 /**
  * Get comprehensive information about a specific tag key
  *
- * @param loader - Schema loader instance
  * @param tagKey - The tag key to get information for (e.g., "parking", "amenity")
  * @returns Tag information including all possible values, type, and field definition status
  */
-export async function getTagInfo(loader: SchemaLoader, tagKey: string): Promise<TagInfo> {
-	const schema = await loader.loadSchema();
+export async function getTagInfo(tagKey: string): Promise<TagInfo> {
+	const schema = await schemaLoader.loadSchema();
 
 	// Collect all unique values for the tag key
 	const values = new Set<string>();
@@ -90,12 +89,12 @@ export async function getTagInfo(loader: SchemaLoader, tagKey: string): Promise<
 /**
  * Handler for get_tag_info tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const tagKey = (args as { tagKey?: string }).tagKey;
 	if (!tagKey) {
 		throw new Error("tagKey parameter is required");
 	}
-	const info = await getTagInfo(loader, tagKey);
+	const info = await getTagInfo(tagKey);
 	return {
 		content: [
 			{

--- a/src/tools/get-tag-values.ts
+++ b/src/tools/get-tag-values.ts
@@ -1,4 +1,4 @@
-import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 
 /**
  * Tool definition for get_tag_values
@@ -21,12 +21,11 @@ export const definition = {
 /**
  * Get all possible values for a given tag key
  *
- * @param loader - Schema loader instance
  * @param tagKey - The tag key to get values for (e.g., "amenity", "building")
  * @returns Array of unique values for the tag key, sorted alphabetically
  */
-export async function getTagValues(loader: SchemaLoader, tagKey: string): Promise<string[]> {
-	const schema = await loader.loadSchema();
+export async function getTagValues(tagKey: string): Promise<string[]> {
+	const schema = await schemaLoader.loadSchema();
 
 	// Collect all unique values for the tag key
 	const values = new Set<string>();
@@ -79,12 +78,12 @@ export async function getTagValues(loader: SchemaLoader, tagKey: string): Promis
 /**
  * Handler for get_tag_values tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const tagKey = (args as { tagKey?: string }).tagKey;
 	if (!tagKey) {
 		throw new Error("tagKey parameter is required");
 	}
-	const values = await getTagValues(loader, tagKey);
+	const values = await getTagValues(tagKey);
 	return {
 		content: [
 			{

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,7 +2,6 @@
  * Tool registry - exports all tools with their definitions and handlers
  */
 
-import type { SchemaLoader } from "../utils/schema-loader.js";
 import * as checkDeprecated from "./check-deprecated.js";
 import * as getCategories from "./get-categories.js";
 import * as getCategoryTags from "./get-category-tags.js";
@@ -34,10 +33,7 @@ export interface ToolDefinition {
 /**
  * Tool handler function signature
  */
-export type ToolHandler = (
-	loader: SchemaLoader,
-	args: unknown,
-) => Promise<{
+export type ToolHandler = (args: unknown) => Promise<{
 	content: Array<{ type: "text"; text: string }>;
 }>;
 

--- a/src/tools/search-presets.ts
+++ b/src/tools/search-presets.ts
@@ -1,5 +1,5 @@
 import type { GeometryType } from "../types/index.js";
-import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { PresetSearchResult } from "./types.js";
 
 /**
@@ -41,17 +41,15 @@ export interface SearchPresetsOptions {
 /**
  * Search for presets by keyword or tag
  *
- * @param loader - Schema loader instance
  * @param keyword - Keyword to search for in preset IDs and tags
  * @param options - Optional search options (limit, geometry filter)
  * @returns Array of matching presets with id, tags, and geometry
  */
 export async function searchPresets(
-	loader: SchemaLoader,
 	keyword: string,
 	options?: SearchPresetsOptions,
 ): Promise<PresetSearchResult[]> {
-	const schema = await loader.loadSchema();
+	const schema = await schemaLoader.loadSchema();
 	const results: PresetSearchResult[] = [];
 
 	// Normalize keyword for case-insensitive search
@@ -128,7 +126,7 @@ export async function searchPresets(
 /**
  * Handler for search_presets tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { keyword, limit, geometry } = args as {
 		keyword?: string;
 		limit?: number;
@@ -137,7 +135,7 @@ export async function handler(loader: SchemaLoader, args: unknown) {
 	if (!keyword) {
 		throw new Error("keyword parameter is required");
 	}
-	const results = await searchPresets(loader, keyword, { limit, geometry });
+	const results = await searchPresets(keyword, { limit, geometry });
 	return {
 		content: [
 			{

--- a/src/tools/search-tags.ts
+++ b/src/tools/search-tags.ts
@@ -1,4 +1,4 @@
-import type { SchemaLoader } from "../utils/schema-loader.js";
+import { schemaLoader } from "../utils/schema-loader.js";
 import type { TagSearchResult } from "./types.js";
 
 /**
@@ -26,17 +26,12 @@ export const definition = {
 /**
  * Search for tags by keyword
  *
- * @param loader - Schema loader instance
  * @param keyword - Keyword to search for in tag keys (from fields), values, and preset names
  * @param limit - Maximum number of results to return (optional, returns all by default)
  * @returns Array of matching tags with key, value, and optional preset name
  */
-export async function searchTags(
-	loader: SchemaLoader,
-	keyword: string,
-	limit?: number,
-): Promise<TagSearchResult[]> {
-	const schema = await loader.loadSchema();
+export async function searchTags(keyword: string, limit?: number): Promise<TagSearchResult[]> {
+	const schema = await schemaLoader.loadSchema();
 	const results: TagSearchResult[] = [];
 	const seen = new Set<string>(); // Track unique key-value pairs
 
@@ -144,12 +139,12 @@ export async function searchTags(
 /**
  * Handler for search_tags tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { keyword, limit } = args as { keyword?: string; limit?: number };
 	if (!keyword) {
 		throw new Error("keyword parameter is required");
 	}
-	const results = await searchTags(loader, keyword, limit);
+	const results = await searchTags(keyword, limit);
 	return {
 		content: [
 			{

--- a/src/tools/suggest-improvements.ts
+++ b/src/tools/suggest-improvements.ts
@@ -1,6 +1,5 @@
 import fields from "@openstreetmap/id-tagging-schema/dist/fields.json" with { type: "json" };
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
-import type { SchemaLoader } from "../utils/schema-loader.js";
 import { checkDeprecated } from "./check-deprecated.js";
 
 /**
@@ -45,12 +44,10 @@ export interface ImprovementResult {
  * warnings about deprecated tags, and recommendations based on
  * matched presets.
  *
- * @param loader - Schema loader instance
  * @param tags - Tag collection to analyze
  * @returns Improvement suggestions and warnings
  */
 export async function suggestImprovements(
-	loader: SchemaLoader,
 	tags: Record<string, string>,
 ): Promise<ImprovementResult> {
 	const result: ImprovementResult = {
@@ -66,7 +63,7 @@ export async function suggestImprovements(
 
 	// Check for deprecated tags
 	for (const [key, value] of Object.entries(tags)) {
-		const deprecationResult = await checkDeprecated(loader, key, value);
+		const deprecationResult = await checkDeprecated(key, value);
 		if (deprecationResult.deprecated) {
 			result.warnings.push(`Tag ${key}=${value} is deprecated. ${deprecationResult.message}`);
 		}
@@ -181,12 +178,12 @@ function getFieldKey(fieldId: string): string | null {
 /**
  * Handler for suggest_improvements tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { tags } = args as { tags?: Record<string, string> };
 	if (!tags) {
 		throw new Error("tags parameter is required");
 	}
-	const result = await suggestImprovements(loader, tags);
+	const result = await suggestImprovements(tags);
 	return {
 		content: [
 			{

--- a/src/tools/validate-tag-collection.ts
+++ b/src/tools/validate-tag-collection.ts
@@ -1,4 +1,3 @@
-import type { SchemaLoader } from "../utils/schema-loader.js";
 import { type ValidationResult, validateTag } from "./validate-tag.js";
 
 /**
@@ -47,12 +46,10 @@ export interface CollectionValidationResult {
 /**
  * Validate a collection of OSM tags
  *
- * @param loader - Schema loader instance
  * @param tags - Object containing key-value pairs to validate
  * @returns Validation result with aggregated statistics and individual tag results
  */
 export async function validateTagCollection(
-	loader: SchemaLoader,
 	tags: Record<string, string>,
 ): Promise<CollectionValidationResult> {
 	const result: CollectionValidationResult = {
@@ -67,7 +64,7 @@ export async function validateTagCollection(
 
 	// Validate each tag individually
 	for (const [key, value] of Object.entries(tags)) {
-		const tagResult = await validateTag(loader, key, value);
+		const tagResult = await validateTag(key, value);
 		result.tagResults[key] = tagResult;
 
 		// Aggregate statistics
@@ -95,12 +92,12 @@ export async function validateTagCollection(
 /**
  * Handler for validate_tag_collection tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { tags } = args as { tags?: Record<string, string> };
 	if (!tags) {
 		throw new Error("tags parameter is required");
 	}
-	const result = await validateTagCollection(loader, tags);
+	const result = await validateTagCollection(tags);
 	return {
 		content: [
 			{

--- a/src/tools/validate-tag.ts
+++ b/src/tools/validate-tag.ts
@@ -2,7 +2,6 @@ import deprecated from "@openstreetmap/id-tagging-schema/dist/deprecated.json" w
 	type: "json",
 };
 import fields from "@openstreetmap/id-tagging-schema/dist/fields.json" with { type: "json" };
-import type { SchemaLoader } from "../utils/schema-loader.js";
 
 /**
  * Tool definition for validate_tag
@@ -46,16 +45,11 @@ export interface ValidationResult {
 /**
  * Validate a single OSM tag (key-value pair)
  *
- * @param _loader - Schema loader instance (reserved for future use)
  * @param key - Tag key to validate
  * @param value - Tag value to validate
  * @returns Validation result with errors, warnings, and deprecation info
  */
-export async function validateTag(
-	_loader: SchemaLoader,
-	key: string,
-	value: string,
-): Promise<ValidationResult> {
+export async function validateTag(key: string, value: string): Promise<ValidationResult> {
 	const result: ValidationResult = {
 		valid: true,
 		deprecated: false,
@@ -150,7 +144,7 @@ export async function validateTag(
 /**
  * Handler for validate_tag tool
  */
-export async function handler(loader: SchemaLoader, args: unknown) {
+export async function handler(args: unknown) {
 	const { key, value } = args as { key?: string; value?: string };
 	if (key === undefined) {
 		throw new Error("key parameter is required");
@@ -158,7 +152,7 @@ export async function handler(loader: SchemaLoader, args: unknown) {
 	if (value === undefined) {
 		throw new Error("value parameter is required");
 	}
-	const result = await validateTag(loader, key, value);
+	const result = await validateTag(key, value);
 	return {
 		content: [
 			{

--- a/src/utils/schema-loader.ts
+++ b/src/utils/schema-loader.ts
@@ -400,3 +400,9 @@ export class SchemaLoader {
 		logger.debug("Schema structure validation passed", "SchemaLoader");
 	}
 }
+
+/**
+ * Singleton instance of SchemaLoader
+ * This instance is shared across all tool modules
+ */
+export const schemaLoader = new SchemaLoader();

--- a/tests/tools/check-deprecated.test.ts
+++ b/tests/tools/check-deprecated.test.ts
@@ -4,19 +4,16 @@ import deprecated from "@openstreetmap/id-tagging-schema/dist/deprecated.json" w
 	type: "json",
 };
 import { checkDeprecated } from "../../src/tools/check-deprecated.js";
-import { SchemaLoader } from "../../src/utils/schema-loader.js";
 
 describe("checkDeprecated", () => {
 	describe("Basic Functionality", () => {
 		it("should check if a tag key-value pair is deprecated", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Use first deprecated entry
 			const entry = deprecated[0];
 			const key = Object.keys(entry.old)[0];
 			const value = entry.old[key as keyof typeof entry.old];
 
-			const result = await checkDeprecated(loader, key, value as string);
+			const result = await checkDeprecated(key, value as string);
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecated, true);
@@ -25,9 +22,7 @@ describe("checkDeprecated", () => {
 		});
 
 		it("should return not deprecated for valid non-deprecated tag", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const result = await checkDeprecated(loader, "amenity", "parking");
+			const result = await checkDeprecated("amenity", "parking");
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecated, false);
@@ -35,15 +30,13 @@ describe("checkDeprecated", () => {
 		});
 
 		it("should check tag by key only (any value)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Find a deprecated entry
 			const entry = deprecated.find((e) => Object.keys(e.old).length === 1);
 			assert.ok(entry);
 
 			const key = Object.keys(entry.old)[0];
 
-			const result = await checkDeprecated(loader, key);
+			const result = await checkDeprecated(key);
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecated, true);
@@ -51,8 +44,6 @@ describe("checkDeprecated", () => {
 		});
 
 		it("should return full replacement object", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Find entry with multiple replacement tags
 			const entry = deprecated.find((e) => e.replace && Object.keys(e.replace).length > 1);
 			assert.ok(entry);
@@ -60,7 +51,7 @@ describe("checkDeprecated", () => {
 			const key = Object.keys(entry.old)[0];
 			const value = entry.old[key as keyof typeof entry.old];
 
-			const result = await checkDeprecated(loader, key, value as string);
+			const result = await checkDeprecated(key, value as string);
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecated, true);
@@ -71,9 +62,7 @@ describe("checkDeprecated", () => {
 
 	describe("Edge Cases", () => {
 		it("should handle key with no deprecated entries", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const result = await checkDeprecated(loader, "nonexistent_key_xyz_12345");
+			const result = await checkDeprecated("nonexistent_key_xyz_12345");
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecated, false);
@@ -81,22 +70,18 @@ describe("checkDeprecated", () => {
 		});
 
 		it("should handle empty key", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const result = await checkDeprecated(loader, "");
+			const result = await checkDeprecated("");
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecated, false);
 		});
 
 		it("should handle key with value that is not deprecated", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Use a key that exists in deprecated but with different value
 			const entry = deprecated[0];
 			const key = Object.keys(entry.old)[0];
 
-			const result = await checkDeprecated(loader, key, "definitely_not_deprecated_value_xyz");
+			const result = await checkDeprecated(key, "definitely_not_deprecated_value_xyz");
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecated, false);
@@ -105,9 +90,7 @@ describe("checkDeprecated", () => {
 
 	describe("Result Structure", () => {
 		it("should return correct result structure", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const result = await checkDeprecated(loader, "amenity", "parking");
+			const result = await checkDeprecated("amenity", "parking");
 
 			assert.ok(result);
 			assert.ok("deprecated" in result);
@@ -118,13 +101,11 @@ describe("checkDeprecated", () => {
 		});
 
 		it("should include old tags in result when deprecated", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			const entry = deprecated[0];
 			const key = Object.keys(entry.old)[0];
 			const value = entry.old[key as keyof typeof entry.old];
 
-			const result = await checkDeprecated(loader, key, value as string);
+			const result = await checkDeprecated(key, value as string);
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecated, true);
@@ -133,13 +114,11 @@ describe("checkDeprecated", () => {
 		});
 
 		it("should include helpful message", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			const entry = deprecated[0];
 			const key = Object.keys(entry.old)[0];
 			const value = entry.old[key as keyof typeof entry.old];
 
-			const result = await checkDeprecated(loader, key, value as string);
+			const result = await checkDeprecated(key, value as string);
 
 			assert.ok(result);
 			assert.ok(result.message);
@@ -150,8 +129,6 @@ describe("checkDeprecated", () => {
 
 	describe("JSON Schema Validation", () => {
 		it("should detect ALL deprecated entries from JSON (100% coverage)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// CRITICAL: Test ALL deprecated entries - no Math.min, no sampling
 			let testedCount = 0;
 			let skippedCount = 0;
@@ -178,7 +155,7 @@ describe("checkDeprecated", () => {
 					continue;
 				}
 
-				const result = await checkDeprecated(loader, key, value as string);
+				const result = await checkDeprecated(key, value as string);
 
 				assert.strictEqual(result.deprecated, true, `Tag ${key}=${value} should be deprecated`);
 				assert.ok(result.replacement, `Tag ${key}=${value} should have replacement`);
@@ -195,13 +172,11 @@ describe("checkDeprecated", () => {
 		});
 
 		it("should return correct replacement from JSON", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			const entry = deprecated[0];
 			const key = Object.keys(entry.old)[0];
 			const value = entry.old[key as keyof typeof entry.old];
 
-			const result = await checkDeprecated(loader, key, value as string);
+			const result = await checkDeprecated(key, value as string);
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecated, true);

--- a/tests/tools/get-categories.test.ts
+++ b/tests/tools/get-categories.test.ts
@@ -4,21 +4,18 @@ import categories from "@openstreetmap/id-tagging-schema/dist/preset_categories.
 	type: "json",
 };
 import { getCategories } from "../../src/tools/get-categories.ts";
-import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("get_categories", () => {
 	describe("Basic Functionality", () => {
 		it("should return an array of categories", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const returnedCategories = await getCategories(loader);
+			const returnedCategories = await getCategories();
 
 			assert.ok(Array.isArray(returnedCategories), "Should return an array");
 			assert.ok(returnedCategories.length > 0, "Should have at least one category");
 		});
 
 		it("should return categories with name and count properties", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const returnedCategories = await getCategories(loader);
+			const returnedCategories = await getCategories();
 
 			const firstCategory = returnedCategories[0];
 			assert.ok(firstCategory, "Should have first category");
@@ -28,8 +25,7 @@ describe("get_categories", () => {
 		});
 
 		it("should return categories sorted by name", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const returnedCategories = await getCategories(loader);
+			const returnedCategories = await getCategories();
 
 			for (let i = 1; i < returnedCategories.length; i++) {
 				const prev = returnedCategories[i - 1];
@@ -42,10 +38,8 @@ describe("get_categories", () => {
 		});
 
 		it("should use cached data on subsequent calls", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const categories1 = await getCategories(loader);
-			const categories2 = await getCategories(loader);
+			const categories1 = await getCategories();
+			const categories2 = await getCategories();
 
 			assert.deepStrictEqual(categories1, categories2, "Categories should be identical from cache");
 		});
@@ -53,8 +47,7 @@ describe("get_categories", () => {
 
 	describe("JSON Schema Validation", () => {
 		it("should return all categories from JSON data", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const returnedCategories = await getCategories(loader);
+			const returnedCategories = await getCategories();
 
 			// Get actual categories from JSON
 			const actualCategoryNames = Object.keys(categories).sort();

--- a/tests/tools/get-category-tags.test.ts
+++ b/tests/tools/get-category-tags.test.ts
@@ -5,52 +5,46 @@ import categories from "@openstreetmap/id-tagging-schema/dist/preset_categories.
 };
 import { getCategories } from "../../src/tools/get-categories.ts";
 import { getCategoryTags } from "../../src/tools/get-category-tags.ts";
-import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("get_category_tags", () => {
 	describe("Basic Functionality", () => {
 		it("should return tags for a valid category", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// First get a valid category name
-			const allCategories = await getCategories(loader);
+			const allCategories = await getCategories();
 			assert.ok(allCategories.length > 0, "Should have categories");
 
 			const categoryName = allCategories[0]?.name;
 			assert.ok(categoryName, "Should have category name");
 
-			const tags = await getCategoryTags(loader, categoryName);
+			const tags = await getCategoryTags(categoryName);
 			assert.ok(Array.isArray(tags), "Should return an array");
 		});
 
 		it("should return preset IDs for category members", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const allCategories = await getCategories(loader);
+			const allCategories = await getCategories();
 
 			// Find a category with members
 			const categoryWithMembers = allCategories.find((cat) => cat.count > 0);
 			assert.ok(categoryWithMembers, "Should have category with members");
 
-			const tags = await getCategoryTags(loader, categoryWithMembers.name);
+			const tags = await getCategoryTags(categoryWithMembers.name);
 			assert.ok(tags.length > 0, "Should have tags");
 			assert.ok(typeof tags[0] === "string", "Tags should be strings (preset IDs)");
 		});
 
 		it("should return empty array for category with no members", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const tags = await getCategoryTags(loader, "nonexistent-category");
+			const tags = await getCategoryTags("nonexistent-category");
 
 			assert.ok(Array.isArray(tags), "Should return an array");
 			assert.strictEqual(tags.length, 0, "Should be empty for nonexistent category");
 		});
 
 		it("should use cached data on subsequent calls", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const allCategories = await getCategories(loader);
+			const allCategories = await getCategories();
 			const categoryName = allCategories[0]?.name || "";
 
-			const tags1 = await getCategoryTags(loader, categoryName);
-			const tags2 = await getCategoryTags(loader, categoryName);
+			const tags1 = await getCategoryTags(categoryName);
+			const tags2 = await getCategoryTags(categoryName);
 
 			assert.deepStrictEqual(tags1, tags2, "Tags should be identical from cache");
 		});
@@ -72,13 +66,9 @@ describe("get_category_tags", () => {
 		}
 
 		it("should return correct data for each category using provider pattern", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Use provider to test each category individually
 			for (const testCase of categoryProvider()) {
-				const returnedCategory = (await getCategories(loader)).find(
-					(cat) => cat.name === testCase.name,
-				);
+				const returnedCategory = (await getCategories()).find((cat) => cat.name === testCase.name);
 
 				assert.ok(returnedCategory, `Category "${testCase.name}" should exist in returned data`);
 				assert.strictEqual(
@@ -87,7 +77,7 @@ describe("get_category_tags", () => {
 					`Category "${testCase.name}" should have correct count`,
 				);
 
-				const tags = await getCategoryTags(loader, testCase.name);
+				const tags = await getCategoryTags(testCase.name);
 				assert.deepStrictEqual(
 					tags,
 					testCase.expectedMembers,
@@ -97,8 +87,6 @@ describe("get_category_tags", () => {
 		});
 
 		it("should return correct preset IDs for specific categories", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Test a few categories
 			const testCategories = ["path", "building", "natural"];
 
@@ -106,7 +94,7 @@ describe("get_category_tags", () => {
 				const actualCategory = categories[categoryName];
 				if (!actualCategory) continue;
 
-				const tags = await getCategoryTags(loader, categoryName);
+				const tags = await getCategoryTags(categoryName);
 				const expectedMembers = actualCategory.members || [];
 
 				assert.deepStrictEqual(

--- a/tests/tools/get-preset-details.test.ts
+++ b/tests/tools/get-preset-details.test.ts
@@ -2,13 +2,11 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
 import { getPresetDetails } from "../../src/tools/get-preset-details.ts";
-import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("get_preset_details", () => {
 	describe("Basic Functionality", () => {
 		it("should return complete preset details for a valid preset ID", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetDetails(loader, "amenity/restaurant");
+			const result = await getPresetDetails("amenity/restaurant");
 
 			assert.ok(result, "Should return a result");
 			assert.strictEqual(result.id, "amenity/restaurant");
@@ -17,8 +15,7 @@ describe("get_preset_details", () => {
 		});
 
 		it("should return all required properties", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetDetails(loader, "amenity/restaurant");
+			const result = await getPresetDetails("amenity/restaurant");
 
 			// Required properties
 			assert.strictEqual(typeof result.id, "string");
@@ -41,8 +38,7 @@ describe("get_preset_details", () => {
 		});
 
 		it("should return tags object with correct structure", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetDetails(loader, "amenity/restaurant");
+			const result = await getPresetDetails("amenity/restaurant");
 
 			assert.ok(result.tags);
 			assert.strictEqual(typeof result.tags, "object");
@@ -50,16 +46,14 @@ describe("get_preset_details", () => {
 		});
 
 		it("should return geometry array", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetDetails(loader, "amenity/restaurant");
+			const result = await getPresetDetails("amenity/restaurant");
 
 			assert.ok(Array.isArray(result.geometry));
 			assert.ok(result.geometry.length > 0, "Should have at least one geometry type");
 		});
 
 		it("should return fields array for presets with fields", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetDetails(loader, "amenity/restaurant");
+			const result = await getPresetDetails("amenity/restaurant");
 
 			assert.ok(result.fields, "Restaurant preset should have fields");
 			assert.ok(Array.isArray(result.fields));
@@ -67,11 +61,9 @@ describe("get_preset_details", () => {
 		});
 
 		it("should throw error for non-existent preset", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			await assert.rejects(
 				async () => {
-					await getPresetDetails(loader, "nonexistent/preset");
+					await getPresetDetails("nonexistent/preset");
 				},
 				{
 					message: /Preset .* not found/,
@@ -80,10 +72,8 @@ describe("get_preset_details", () => {
 		});
 
 		it("should use cached data on subsequent calls", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const result1 = await getPresetDetails(loader, "amenity/cafe");
-			const result2 = await getPresetDetails(loader, "amenity/cafe");
+			const result1 = await getPresetDetails("amenity/cafe");
+			const result2 = await getPresetDetails("amenity/cafe");
 
 			assert.deepStrictEqual(result1, result2, "Results should be identical from cache");
 		});
@@ -91,8 +81,7 @@ describe("get_preset_details", () => {
 
 	describe("JSON Schema Validation", () => {
 		it("should return preset details matching JSON data exactly", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetDetails(loader, "amenity/restaurant");
+			const result = await getPresetDetails("amenity/restaurant");
 
 			const expected = presets["amenity/restaurant"];
 			assert.ok(expected, "Preset should exist in JSON");
@@ -125,15 +114,13 @@ describe("get_preset_details", () => {
 		});
 
 		it("should validate ALL preset details via provider pattern (100% coverage)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// CRITICAL: Test EVERY preset from JSON, not a sample
 			const allPresetIds = Object.keys(presets);
 			assert.ok(allPresetIds.length > 1500, "Should have all presets from JSON");
 
 			// Provider pattern: iterate through EVERY preset
 			for (const presetId of allPresetIds) {
-				const result = await getPresetDetails(loader, presetId);
+				const result = await getPresetDetails(presetId);
 				const expected = presets[presetId];
 
 				assert.ok(expected, `Preset ${presetId} should exist in JSON`);
@@ -184,8 +171,6 @@ describe("get_preset_details", () => {
 		});
 
 		it("should handle presets without optional fields", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Find a preset without fields (if any exist)
 			let presetWithoutFields: string | null = null;
 			for (const [id, preset] of Object.entries(presets)) {
@@ -196,7 +181,7 @@ describe("get_preset_details", () => {
 			}
 
 			if (presetWithoutFields) {
-				const result = await getPresetDetails(loader, presetWithoutFields);
+				const result = await getPresetDetails(presetWithoutFields);
 				assert.ok(result);
 				assert.strictEqual(result.id, presetWithoutFields);
 				// fields should be undefined or not present

--- a/tests/tools/get-preset-tags.test.ts
+++ b/tests/tools/get-preset-tags.test.ts
@@ -2,13 +2,11 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
 import { getPresetTags } from "../../src/tools/get-preset-tags.ts";
-import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("get_preset_tags", () => {
 	describe("Basic Functionality", () => {
 		it("should return tags for a valid preset ID", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetTags(loader, "amenity/restaurant");
+			const result = await getPresetTags("amenity/restaurant");
 
 			assert.ok(result, "Should return a result");
 			assert.ok(result.tags, "Should have tags property");
@@ -16,16 +14,13 @@ describe("get_preset_tags", () => {
 		});
 
 		it("should return the correct identifying tags", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetTags(loader, "amenity/restaurant");
+			const result = await getPresetTags("amenity/restaurant");
 
 			assert.ok(result.tags);
 			assert.strictEqual(result.tags.amenity, "restaurant");
 		});
 
 		it("should include addTags if present in preset", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Find a preset with addTags
 			let presetWithAddTags: string | null = null;
 			for (const [id, preset] of Object.entries(presets)) {
@@ -36,15 +31,14 @@ describe("get_preset_tags", () => {
 			}
 
 			if (presetWithAddTags) {
-				const result = await getPresetTags(loader, presetWithAddTags);
+				const result = await getPresetTags(presetWithAddTags);
 				assert.ok(result.addTags, "Should have addTags for preset with addTags");
 				assert.strictEqual(typeof result.addTags, "object");
 			}
 		});
 
 		it("should not include addTags if not present in preset", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetTags(loader, "amenity/restaurant");
+			const result = await getPresetTags("amenity/restaurant");
 
 			const preset = presets["amenity/restaurant"];
 			if (!preset.addTags || Object.keys(preset.addTags).length === 0) {
@@ -56,11 +50,9 @@ describe("get_preset_tags", () => {
 		});
 
 		it("should throw error for non-existent preset", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			await assert.rejects(
 				async () => {
-					await getPresetTags(loader, "nonexistent/preset");
+					await getPresetTags("nonexistent/preset");
 				},
 				{
 					message: /Preset .* not found/,
@@ -69,10 +61,8 @@ describe("get_preset_tags", () => {
 		});
 
 		it("should use cached data on subsequent calls", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const result1 = await getPresetTags(loader, "amenity/cafe");
-			const result2 = await getPresetTags(loader, "amenity/cafe");
+			const result1 = await getPresetTags("amenity/cafe");
+			const result2 = await getPresetTags("amenity/cafe");
 
 			assert.deepStrictEqual(result1, result2, "Results should be identical from cache");
 		});
@@ -80,8 +70,7 @@ describe("get_preset_tags", () => {
 
 	describe("JSON Schema Validation", () => {
 		it("should return tags matching JSON data exactly", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetTags(loader, "amenity/restaurant");
+			const result = await getPresetTags("amenity/restaurant");
 
 			const expected = presets["amenity/restaurant"];
 			assert.ok(expected, "Preset should exist in JSON");
@@ -96,15 +85,13 @@ describe("get_preset_tags", () => {
 		});
 
 		it("should validate tags for ALL presets via provider pattern (100% coverage)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// CRITICAL: Test EVERY preset from JSON, not a sample
 			const allPresetIds = Object.keys(presets);
 			assert.ok(allPresetIds.length > 1500, "Should have all presets from JSON");
 
 			// Provider pattern: iterate through EVERY preset
 			for (const presetId of allPresetIds) {
-				const result = await getPresetTags(loader, presetId);
+				const result = await getPresetTags(presetId);
 				const expected = presets[presetId];
 
 				assert.ok(expected, `Preset ${presetId} should exist in JSON`);
@@ -133,8 +120,7 @@ describe("get_preset_tags", () => {
 		});
 
 		it("should return tags as key-value pairs", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await getPresetTags(loader, "amenity/restaurant");
+			const result = await getPresetTags("amenity/restaurant");
 
 			assert.ok(result.tags);
 			assert.strictEqual(typeof result.tags, "object");

--- a/tests/tools/get-related-tags.test.ts
+++ b/tests/tools/get-related-tags.test.ts
@@ -2,29 +2,25 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
 import { getRelatedTags } from "../../src/tools/get-related-tags.ts";
-import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("get_related_tags", () => {
 	describe("Basic Functionality", () => {
 		it("should return related tags for a tag key", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await getRelatedTags(loader, "amenity");
+			const results = await getRelatedTags("amenity");
 
 			assert.ok(Array.isArray(results), "Should return an array");
 			assert.ok(results.length > 0, "Should find related tags");
 		});
 
 		it("should return related tags for a key=value pair", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await getRelatedTags(loader, "amenity=restaurant");
+			const results = await getRelatedTags("amenity=restaurant");
 
 			assert.ok(Array.isArray(results), "Should return an array");
 			assert.ok(results.length > 0, "Should find related tags");
 		});
 
 		it("should return tags with required properties", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await getRelatedTags(loader, "amenity=cafe");
+			const results = await getRelatedTags("amenity=cafe");
 
 			assert.ok(results.length > 0, "Should have results");
 			const first = results[0];
@@ -35,8 +31,7 @@ describe("get_related_tags", () => {
 		});
 
 		it("should sort results by frequency (descending)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await getRelatedTags(loader, "amenity=parking");
+			const results = await getRelatedTags("amenity=parking");
 
 			assert.ok(results.length > 1, "Should have multiple results");
 			for (let i = 1; i < results.length; i++) {
@@ -48,16 +43,14 @@ describe("get_related_tags", () => {
 		});
 
 		it("should limit results when limit parameter is provided", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const limit = 5;
-			const results = await getRelatedTags(loader, "amenity", limit);
+			const results = await getRelatedTags("amenity", limit);
 
 			assert.ok(results.length <= limit, `Should return at most ${limit} results`);
 		});
 
 		it("should exclude the input tag itself from results", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await getRelatedTags(loader, "amenity=restaurant");
+			const results = await getRelatedTags("amenity=restaurant");
 
 			// Should not include amenity=restaurant in the results
 			const hasSelf = results.some((r) => r.key === "amenity" && r.value === "restaurant");
@@ -65,25 +58,21 @@ describe("get_related_tags", () => {
 		});
 
 		it("should return empty array for non-existent tag", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await getRelatedTags(loader, "nonexistent=fakeval12345xyz");
+			const results = await getRelatedTags("nonexistent=fakeval12345xyz");
 
 			assert.ok(Array.isArray(results), "Should return an array");
 			assert.strictEqual(results.length, 0, "Should return empty array");
 		});
 
 		it("should use cached data on subsequent calls", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const results1 = await getRelatedTags(loader, "amenity=hospital");
-			const results2 = await getRelatedTags(loader, "amenity=hospital");
+			const results1 = await getRelatedTags("amenity=hospital");
+			const results2 = await getRelatedTags("amenity=hospital");
 
 			assert.deepStrictEqual(results1, results2, "Results should be identical from cache");
 		});
 
 		it("should handle tag key without specific value", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await getRelatedTags(loader, "building");
+			const results = await getRelatedTags("building");
 
 			assert.ok(Array.isArray(results), "Should return an array");
 			// When searching for just "building" key, should find tags that appear
@@ -127,8 +116,7 @@ describe("get_related_tags", () => {
 		}
 
 		it("should return related tags that exist in JSON presets", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await getRelatedTags(loader, "amenity=restaurant", 20);
+			const results = await getRelatedTags("amenity=restaurant", 20);
 
 			// Verify each related tag exists in JSON presets
 			for (const result of results) {
@@ -159,12 +147,10 @@ describe("get_related_tags", () => {
 		});
 
 		it("should systematically test related tags for dynamic preset samples (100% data-driven)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// CRITICAL: Test dynamically sampled tags from JSON - NO hardcoded values
 			let testedCount = 0;
 			for (const testCase of tagCombinationProvider()) {
-				const results = await getRelatedTags(loader, testCase.tag, 10);
+				const results = await getRelatedTags(testCase.tag, 10);
 
 				// Verify each related tag exists in JSON presets
 				for (const result of results) {
@@ -201,9 +187,8 @@ describe("get_related_tags", () => {
 		});
 
 		it("should verify frequency counts match actual preset occurrences", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tag = "amenity=cafe";
-			const results = await getRelatedTags(loader, tag, 10);
+			const results = await getRelatedTags(tag, 10);
 
 			// For each related tag, verify frequency matches actual count in presets
 			for (const result of results) {
@@ -235,8 +220,7 @@ describe("get_related_tags", () => {
 		});
 
 		it("should find related tags that co-occur in presets", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await getRelatedTags(loader, "amenity=parking");
+			const results = await getRelatedTags("amenity=parking");
 
 			// Check that results are tags that actually appear with amenity=parking
 			// in the JSON data

--- a/tests/tools/get-schema-stats.test.ts
+++ b/tests/tools/get-schema-stats.test.ts
@@ -6,13 +6,12 @@ import categories from "@openstreetmap/id-tagging-schema/dist/preset_categories.
 };
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
 import { getSchemaStats } from "../../src/tools/get-schema-stats.ts";
-import { SchemaLoader } from "../../src/utils/schema-loader.ts";
+import { schemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("get_schema_stats", () => {
 	describe("Basic Functionality", () => {
 		it("should return schema statistics with preset count", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const stats = await getSchemaStats(loader);
+			const stats = await getSchemaStats();
 
 			assert.ok(stats, "Stats should be returned");
 			assert.ok(typeof stats.presetCount === "number", "Should have preset count");
@@ -20,34 +19,29 @@ describe("get_schema_stats", () => {
 		});
 
 		it("should return schema statistics with field count", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const stats = await getSchemaStats(loader);
+			const stats = await getSchemaStats();
 
 			assert.ok(typeof stats.fieldCount === "number", "Should have field count");
 			assert.ok(stats.fieldCount > 0, "Field count should be greater than 0");
 		});
 
 		it("should return schema statistics with category count", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const stats = await getSchemaStats(loader);
+			const stats = await getSchemaStats();
 
 			assert.ok(typeof stats.categoryCount === "number", "Should have category count");
 			assert.ok(stats.categoryCount > 0, "Category count should be greater than 0");
 		});
 
 		it("should return schema statistics with deprecated tag count", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const stats = await getSchemaStats(loader);
+			const stats = await getSchemaStats();
 
 			assert.ok(typeof stats.deprecatedCount === "number", "Should have deprecated count");
 			assert.ok(stats.deprecatedCount >= 0, "Deprecated count should be non-negative");
 		});
 
 		it("should use cached data on subsequent calls", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const stats1 = await getSchemaStats(loader);
-			const stats2 = await getSchemaStats(loader);
+			const stats1 = await getSchemaStats();
+			const stats2 = await getSchemaStats();
 
 			assert.deepStrictEqual(stats1, stats2, "Stats should be identical from cache");
 		});
@@ -77,8 +71,7 @@ describe("get_schema_stats", () => {
 		}
 
 		it("should return stats matching actual JSON data counts", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const stats = await getSchemaStats(loader);
+			const stats = await getSchemaStats();
 
 			// Verify preset count matches JSON data
 			const actualPresetCount = Object.keys(presets).length;
@@ -106,7 +99,7 @@ describe("get_schema_stats", () => {
 		});
 
 		it("should verify ALL preset keys exist in schema (100% coverage)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
+			const loader = schemaLoader;
 			const schema = await loader.loadSchema();
 			const schemaPresetKeys = Object.keys(schema.presets);
 
@@ -130,7 +123,7 @@ describe("get_schema_stats", () => {
 		});
 
 		it("should verify ALL field keys exist in schema (100% coverage)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
+			const loader = schemaLoader;
 			const schema = await loader.loadSchema();
 			const schemaFieldKeys = Object.keys(schema.fields);
 

--- a/tests/tools/get-tag-info.test.ts
+++ b/tests/tools/get-tag-info.test.ts
@@ -3,13 +3,11 @@ import { describe, it } from "node:test";
 import fields from "@openstreetmap/id-tagging-schema/dist/fields.json" with { type: "json" };
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
 import { getTagInfo } from "../../src/tools/get-tag-info.ts";
-import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("get_tag_info", () => {
 	describe("Basic Functionality", () => {
 		it("should return info for a valid tag key with field definition", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const info = await getTagInfo(loader, "parking");
+			const info = await getTagInfo("parking");
 
 			assert.ok(info, "Should return tag info");
 			assert.strictEqual(info.key, "parking", "Should return correct key");
@@ -20,8 +18,7 @@ describe("get_tag_info", () => {
 		});
 
 		it("should return info for a tag key without field definition", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const info = await getTagInfo(loader, "amenity");
+			const info = await getTagInfo("amenity");
 
 			assert.ok(info, "Should return tag info");
 			assert.strictEqual(info.key, "amenity", "Should return correct key");
@@ -30,24 +27,21 @@ describe("get_tag_info", () => {
 		});
 
 		it("should return sorted values", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const info = await getTagInfo(loader, "parking");
+			const info = await getTagInfo("parking");
 
 			const sorted = [...info.values].sort();
 			assert.deepStrictEqual(info.values, sorted, "Values should be sorted alphabetically");
 		});
 
 		it("should return unique values only", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const info = await getTagInfo(loader, "building");
+			const info = await getTagInfo("building");
 
 			const uniqueValues = new Set(info.values);
 			assert.strictEqual(info.values.length, uniqueValues.size, "Should return unique values only");
 		});
 
 		it("should handle non-existent tag key", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const info = await getTagInfo(loader, "nonexistent_tag_key_12345");
+			const info = await getTagInfo("nonexistent_tag_key_12345");
 
 			assert.ok(info, "Should return tag info even for non-existent key");
 			assert.strictEqual(info.key, "nonexistent_tag_key_12345", "Should return correct key");
@@ -57,10 +51,9 @@ describe("get_tag_info", () => {
 		});
 
 		it("should accept keys with colon separator (BUG FIX TEST)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			// toilets:wheelchair is a field stored as "toilets/wheelchair" in fields map
 			// but should accept "toilets:wheelchair" as input (OSM format)
-			const info = await getTagInfo(loader, "toilets:wheelchair");
+			const info = await getTagInfo("toilets:wheelchair");
 
 			assert.ok(info, "Should return tag info");
 			assert.strictEqual(info.key, "toilets:wheelchair", "Should return key with colon separator");
@@ -69,9 +62,8 @@ describe("get_tag_info", () => {
 		});
 
 		it("should return keys with colon separator (BUG FIX TEST)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			// Test that returned key uses colon, not slash
-			const info = await getTagInfo(loader, "toilets:wheelchair");
+			const info = await getTagInfo("toilets:wheelchair");
 
 			assert.ok(info, "Should return tag info");
 			assert.ok(!info.key.includes("/"), "Returned key should not contain slash separator");
@@ -79,10 +71,8 @@ describe("get_tag_info", () => {
 		});
 
 		it("should use cached data on subsequent calls", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const info1 = await getTagInfo(loader, "amenity");
-			const info2 = await getTagInfo(loader, "amenity");
+			const info1 = await getTagInfo("amenity");
+			const info2 = await getTagInfo("amenity");
 
 			assert.deepStrictEqual(info1, info2, "Should return identical data from cache");
 		});
@@ -171,10 +161,8 @@ describe("get_tag_info", () => {
 		}
 
 		it("should return ALL values matching JSON data (fields + presets)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Test parking which has comprehensive field definition
-			const info = await getTagInfo(loader, "parking");
+			const info = await getTagInfo("parking");
 
 			// Collect expected values from JSON
 			const expectedValues = new Set<string>();
@@ -228,11 +216,9 @@ describe("get_tag_info", () => {
 		});
 
 		it("should validate ALL tag keys using provider pattern (100% coverage)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// CRITICAL: Test EVERY tag key from provider, NO sampling
 			for (const testCase of tagKeyProvider()) {
-				const info = await getTagInfo(loader, testCase.key);
+				const info = await getTagInfo(testCase.key);
 
 				// Validate hasFieldDefinition matches JSON
 				assert.strictEqual(
@@ -278,10 +264,8 @@ describe("get_tag_info", () => {
 		});
 
 		it("should filter out wildcards and complex patterns from JSON", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Test with building which might have wildcards
-			const info = await getTagInfo(loader, "building");
+			const info = await getTagInfo("building");
 
 			// CRITICAL: Verify EACH value individually (NO wildcards, NO pipes)
 			for (const value of info.values) {
@@ -291,10 +275,8 @@ describe("get_tag_info", () => {
 		});
 
 		it("should validate field definition properties from JSON", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Test parking which has field definition
-			const info = await getTagInfo(loader, "parking");
+			const info = await getTagInfo("parking");
 			const parkingField = fields.parking;
 
 			assert.ok(parkingField, "parking field should exist in fields.json");

--- a/tests/tools/get-tag-values.test.ts
+++ b/tests/tools/get-tag-values.test.ts
@@ -3,65 +3,56 @@ import { describe, it } from "node:test";
 import fields from "@openstreetmap/id-tagging-schema/dist/fields.json" with { type: "json" };
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
 import { getTagValues } from "../../src/tools/get-tag-values.ts";
-import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("get_tag_values", () => {
 	describe("Basic Functionality", () => {
 		it("should return values for a valid tag key", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const values = await getTagValues(loader, "amenity");
+			const values = await getTagValues("amenity");
 
 			assert.ok(Array.isArray(values), "Should return an array");
 			assert.ok(values.length > 0, "Should have at least one value");
 		});
 
 		it("should return unique values only", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const values = await getTagValues(loader, "amenity");
+			const values = await getTagValues("amenity");
 
 			const uniqueValues = new Set(values);
 			assert.strictEqual(values.length, uniqueValues.size, "Should return unique values only");
 		});
 
 		it("should return sorted values", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const values = await getTagValues(loader, "amenity");
+			const values = await getTagValues("amenity");
 
 			const sorted = [...values].sort();
 			assert.deepStrictEqual(values, sorted, "Values should be sorted");
 		});
 
 		it("should return empty array for non-existent tag key", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const values = await getTagValues(loader, "nonexistent_tag_key_12345");
+			const values = await getTagValues("nonexistent_tag_key_12345");
 
 			assert.ok(Array.isArray(values), "Should return an array");
 			assert.strictEqual(values.length, 0, "Should return empty array");
 		});
 
 		it("should use cached data on subsequent calls", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const values1 = await getTagValues(loader, "amenity");
-			const values2 = await getTagValues(loader, "amenity");
+			const values1 = await getTagValues("amenity");
+			const values2 = await getTagValues("amenity");
 
 			assert.deepStrictEqual(values1, values2, "Values should be identical from cache");
 		});
 
 		it("should handle tag keys with special characters", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			// Tags like "addr:street" exist in OSM
-			const values = await getTagValues(loader, "building");
+			const values = await getTagValues("building");
 
 			assert.ok(Array.isArray(values), "Should handle tag keys");
 			// Should not throw error
 		});
 
 		it("should accept keys with colon separator (BUG FIX TEST)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			// toilets:wheelchair is a field stored as "toilets/wheelchair" in fields map
 			// but should accept "toilets:wheelchair" as input (OSM format)
-			const values = await getTagValues(loader, "toilets:wheelchair");
+			const values = await getTagValues("toilets:wheelchair");
 
 			assert.ok(Array.isArray(values), "Should return an array");
 			assert.ok(values.length > 0, "Should find values for colon-formatted key");
@@ -153,8 +144,7 @@ describe("get_tag_values", () => {
 		}
 
 		it("should return tag values that exist in JSON (fields and presets)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const values = await getTagValues(loader, "amenity");
+			const values = await getTagValues("amenity");
 
 			// Collect all amenity values from JSON (fields + presets)
 			const expectedValues = new Set<string>();
@@ -201,11 +191,9 @@ describe("get_tag_values", () => {
 		});
 
 		it("should return correct tag values for multiple keys using provider pattern", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Test each tag key from provider
 			for (const testCase of tagKeyProvider()) {
-				const values = await getTagValues(loader, testCase.key);
+				const values = await getTagValues(testCase.key);
 				const returnedSet = new Set(values);
 
 				// Bidirectional validation: all returned values should exist in expected
@@ -234,10 +222,8 @@ describe("get_tag_values", () => {
 		});
 
 		it("should filter out wildcards and complex patterns from JSON", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Test with a tag that might have wildcards in JSON
-			const values = await getTagValues(loader, "building");
+			const values = await getTagValues("building");
 
 			// Verify no wildcards or pipe-separated values
 			for (const value of values) {
@@ -247,11 +233,9 @@ describe("get_tag_values", () => {
 		});
 
 		it("should validate wildcard filtering across multiple tag keys", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Test multiple keys using provider
 			for (const testCase of tagKeyProvider()) {
-				const values = await getTagValues(loader, testCase.key);
+				const values = await getTagValues(testCase.key);
 
 				// Verify no wildcards or pipe-separated values
 				for (const value of values) {
@@ -269,10 +253,8 @@ describe("get_tag_values", () => {
 		});
 
 		it("should return values from fields.json for keys with field definitions", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Test with "parking" which has comprehensive options in fields.json
-			const values = await getTagValues(loader, "parking");
+			const values = await getTagValues("parking");
 
 			// Get expected values from fields.json
 			const parkingField = fields.parking;

--- a/tests/tools/search-presets.test.ts
+++ b/tests/tools/search-presets.test.ts
@@ -2,13 +2,11 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
 import { searchPresets } from "../../src/tools/search-presets.ts";
-import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("search_presets", () => {
 	describe("Basic Functionality", () => {
 		it("should search presets by ID keyword", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchPresets(loader, "restaurant");
+			const results = await searchPresets("restaurant");
 
 			assert.ok(Array.isArray(results), "Should return an array");
 			assert.ok(results.length > 0, "Should find matching presets");
@@ -19,8 +17,7 @@ describe("search_presets", () => {
 		});
 
 		it("should return preset with required properties", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchPresets(loader, "restaurant");
+			const results = await searchPresets("restaurant");
 
 			assert.ok(results.length > 0, "Should have results");
 			const first = results[0];
@@ -31,8 +28,7 @@ describe("search_presets", () => {
 		});
 
 		it("should search presets by tag", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchPresets(loader, "amenity=restaurant");
+			const results = await searchPresets("amenity=restaurant");
 
 			assert.ok(results.length > 0, "Should find presets with tag");
 
@@ -43,9 +39,8 @@ describe("search_presets", () => {
 		});
 
 		it("should perform case-insensitive search", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const resultsLower = await searchPresets(loader, "restaurant");
-			const resultsUpper = await searchPresets(loader, "RESTAURANT");
+			const resultsLower = await searchPresets("restaurant");
+			const resultsUpper = await searchPresets("RESTAURANT");
 
 			assert.ok(resultsLower.length > 0, "Should find results with lowercase");
 			assert.ok(resultsUpper.length > 0, "Should find results with uppercase");
@@ -53,24 +48,21 @@ describe("search_presets", () => {
 		});
 
 		it("should return empty array for no matches", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchPresets(loader, "nonexistentpresetxyz12345");
+			const results = await searchPresets("nonexistentpresetxyz12345");
 
 			assert.ok(Array.isArray(results), "Should return an array");
 			assert.strictEqual(results.length, 0, "Should return empty array");
 		});
 
 		it("should limit results when limit parameter is provided", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchPresets(loader, "building", { limit: 5 });
+			const results = await searchPresets("building", { limit: 5 });
 
 			assert.ok(Array.isArray(results), "Should return an array");
 			assert.ok(results.length <= 5, "Should respect limit");
 		});
 
 		it("should filter by geometry type", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchPresets(loader, "restaurant", {
+			const results = await searchPresets("restaurant", {
 				geometry: "area",
 			});
 
@@ -86,10 +78,8 @@ describe("search_presets", () => {
 		});
 
 		it("should use cached data on subsequent calls", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const results1 = await searchPresets(loader, "school");
-			const results2 = await searchPresets(loader, "school");
+			const results1 = await searchPresets("school");
+			const results2 = await searchPresets("school");
 
 			assert.deepStrictEqual(results1, results2, "Results should be identical from cache");
 		});
@@ -97,8 +87,7 @@ describe("search_presets", () => {
 
 	describe("JSON Schema Validation", () => {
 		it("should return presets matching JSON data", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchPresets(loader, "restaurant");
+			const results = await searchPresets("restaurant");
 
 			// Verify each result exists in JSON
 			for (const result of results) {
@@ -118,8 +107,7 @@ describe("search_presets", () => {
 		});
 
 		it("should find presets by exact tag match", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchPresets(loader, "amenity=cafe");
+			const results = await searchPresets("amenity=cafe");
 
 			assert.ok(results.length > 0, "Should find cafe presets");
 
@@ -132,8 +120,7 @@ describe("search_presets", () => {
 		});
 
 		it("should validate search results against complete preset data", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchPresets(loader, "parking");
+			const results = await searchPresets("parking");
 
 			assert.ok(results.length > 0, "Should find parking presets");
 
@@ -155,8 +142,6 @@ describe("search_presets", () => {
 		});
 
 		it("should be able to find ALL presets from JSON by ID using provider pattern (100% coverage)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// CRITICAL: Test EVERY preset from JSON, not a sample
 			const allPresetIds = Object.keys(presets);
 			assert.ok(allPresetIds.length > 1500, "Should have all presets from JSON");
@@ -169,7 +154,7 @@ describe("search_presets", () => {
 				// Search by preset ID (use last part for searchable presets)
 				const searchTerm = presetId.split("/").pop() || presetId;
 
-				const results = await searchPresets(loader, searchTerm);
+				const results = await searchPresets(searchTerm);
 
 				// Check if this preset was found in results
 				const found = results.some((r) => r.id === presetId);

--- a/tests/tools/search-tags.test.ts
+++ b/tests/tools/search-tags.test.ts
@@ -3,21 +3,18 @@ import { describe, it } from "node:test";
 import fields from "@openstreetmap/id-tagging-schema/dist/fields.json" with { type: "json" };
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
 import { searchTags } from "../../src/tools/search-tags.ts";
-import { SchemaLoader } from "../../src/utils/schema-loader.ts";
 
 describe("search_tags", () => {
 	describe("Basic Functionality", () => {
 		it("should return tags matching the keyword", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchTags(loader, "restaurant");
+			const results = await searchTags("restaurant");
 
 			assert.ok(Array.isArray(results), "Should return an array");
 			assert.ok(results.length > 0, "Should find matching tags");
 		});
 
 		it("should return tags with key and value properties", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchTags(loader, "cafe");
+			const results = await searchTags("cafe");
 
 			assert.ok(results.length > 0, "Should have results");
 			const first = results[0];
@@ -27,9 +24,8 @@ describe("search_tags", () => {
 		});
 
 		it("should perform case-insensitive search", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const resultsLower = await searchTags(loader, "park");
-			const resultsUpper = await searchTags(loader, "PARK");
+			const resultsLower = await searchTags("park");
+			const resultsUpper = await searchTags("PARK");
 
 			assert.ok(resultsLower.length > 0, "Should find results with lowercase");
 			assert.ok(resultsUpper.length > 0, "Should find results with uppercase");
@@ -37,16 +33,14 @@ describe("search_tags", () => {
 		});
 
 		it("should return empty array for no matches", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchTags(loader, "nonexistentkeywordinosm12345xyz");
+			const results = await searchTags("nonexistentkeywordinosm12345xyz");
 
 			assert.ok(Array.isArray(results), "Should return an array");
 			assert.strictEqual(results.length, 0, "Should return empty array");
 		});
 
 		it("should limit results to prevent overwhelming output", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchTags(loader, "building");
+			const results = await searchTags("building");
 
 			assert.ok(Array.isArray(results), "Should return an array");
 			// Should have reasonable limit, not thousands of results
@@ -54,17 +48,14 @@ describe("search_tags", () => {
 		});
 
 		it("should use cached data on subsequent calls", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
-			const results1 = await searchTags(loader, "school");
-			const results2 = await searchTags(loader, "school");
+			const results1 = await searchTags("school");
+			const results2 = await searchTags("school");
 
 			assert.deepStrictEqual(results1, results2, "Results should be identical from cache");
 		});
 
 		it("should find tag keys from fields.json (BUG FIX TEST)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchTags(loader, "wheelchair");
+			const results = await searchTags("wheelchair");
 
 			// wheelchair exists in fields.json with options: yes, limited, no
 			// This test fails before the bug fix
@@ -88,9 +79,8 @@ describe("search_tags", () => {
 		});
 
 		it("should return keys with colon separator, not slash (BUG FIX TEST)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			// Search for "toilets" to find nested keys like toilets:wheelchair
-			const results = await searchTags(loader, "toilets");
+			const results = await searchTags("toilets");
 
 			assert.ok(results.length > 0, "Should find toilets-related tags");
 
@@ -228,8 +218,7 @@ describe("search_tags", () => {
 		}
 
 		it("should return search results matching JSON data (presets + fields)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const results = await searchTags(loader, "parking");
+			const results = await searchTags("parking");
 
 			// Verify each result corresponds to actual JSON data (presets OR fields)
 			for (const result of results) {
@@ -271,12 +260,10 @@ describe("search_tags", () => {
 		});
 
 		it("should validate search results for multiple keywords using provider pattern", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Test each keyword from provider
 			for (const testCase of searchKeywordProvider()) {
 				// Get limited results (default limit: 100)
-				const results = await searchTags(loader, testCase.keyword);
+				const results = await searchTags(testCase.keyword);
 
 				// Verify all returned results exist in JSON (fields OR presets)
 				for (const result of results) {

--- a/tests/tools/suggest-improvements.test.ts
+++ b/tests/tools/suggest-improvements.test.ts
@@ -5,17 +5,15 @@ import deprecated from "@openstreetmap/id-tagging-schema/dist/deprecated.json" w
 };
 import presets from "@openstreetmap/id-tagging-schema/dist/presets.json" with { type: "json" };
 import { suggestImprovements } from "../../src/tools/suggest-improvements.js";
-import { SchemaLoader } from "../../src/utils/schema-loader.js";
 
 describe("suggestImprovements", () => {
 	describe("Basic Functionality", () => {
 		it("should return suggestions for tag collection", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "restaurant",
 			};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			assert.ok("suggestions" in result);
@@ -25,12 +23,11 @@ describe("suggestImprovements", () => {
 		});
 
 		it("should suggest missing common tags", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "restaurant",
 			};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			assert.ok(result.suggestions.length > 0);
@@ -38,8 +35,6 @@ describe("suggestImprovements", () => {
 		});
 
 		it("should warn about deprecated tags", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Use first deprecated entry
 			const entry = deprecated[0];
 			const key = Object.keys(entry.old)[0];
@@ -49,7 +44,7 @@ describe("suggestImprovements", () => {
 				[key]: value as string,
 			};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			assert.ok(result.warnings.length > 0);
@@ -57,8 +52,6 @@ describe("suggestImprovements", () => {
 		});
 
 		it("should return empty suggestions for complete tag set", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Find a preset and use its complete tag set
 			const preset = Object.values(presets)[0];
 			const tags: Record<string, string> = {};
@@ -78,17 +71,16 @@ describe("suggestImprovements", () => {
 				}
 			}
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			// Should have fewer suggestions since tags are more complete
 		});
 
 		it("should handle empty tag collection", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			assert.strictEqual(result.suggestions.length, 0);
@@ -98,12 +90,11 @@ describe("suggestImprovements", () => {
 
 	describe("Result Structure", () => {
 		it("should return correct result structure", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "parking",
 			};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			assert.ok("suggestions" in result);
@@ -115,12 +106,11 @@ describe("suggestImprovements", () => {
 		});
 
 		it("should include matched presets", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "restaurant",
 			};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			assert.ok(result.matchedPresets);
@@ -128,12 +118,11 @@ describe("suggestImprovements", () => {
 		});
 
 		it("should have meaningful suggestion messages", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "restaurant",
 			};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			if (result.suggestions.length > 0) {
@@ -147,13 +136,12 @@ describe("suggestImprovements", () => {
 
 	describe("Preset Matching", () => {
 		it("should match presets based on tags", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "restaurant",
 				cuisine: "italian",
 			};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			assert.ok(result.matchedPresets);
@@ -161,12 +149,11 @@ describe("suggestImprovements", () => {
 		});
 
 		it("should suggest fields from matched presets", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "parking",
 			};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			// Parking should have suggestions like capacity, fee, surface, etc.
@@ -176,8 +163,6 @@ describe("suggestImprovements", () => {
 
 	describe("Deprecation Warnings", () => {
 		it("should warn about ALL deprecated tags (100% coverage)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// CRITICAL: Test ALL deprecated entries individually - no Math.min, no sampling
 			let testedCount = 0;
 			let skippedCount = 0;
@@ -210,7 +195,7 @@ describe("suggestImprovements", () => {
 				}
 
 				const tags = { [key]: value };
-				const result = await suggestImprovements(loader, tags);
+				const result = await suggestImprovements(tags);
 
 				assert.ok(result, `Should return result for deprecated tag ${key}=${value}`);
 				assert.ok(result.warnings.length >= 1, `Should warn about deprecated tag ${key}=${value}`);
@@ -233,8 +218,6 @@ describe("suggestImprovements", () => {
 
 	describe("JSON Schema Validation", () => {
 		it("should suggest fields from preset fields", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Use a known preset
 			const preset = presets["amenity/restaurant"];
 			if (preset?.tags) {
@@ -245,7 +228,7 @@ describe("suggestImprovements", () => {
 					}
 				}
 
-				const result = await suggestImprovements(loader, tags);
+				const result = await suggestImprovements(tags);
 
 				assert.ok(result);
 				assert.ok(result.matchedPresets);
@@ -258,24 +241,22 @@ describe("suggestImprovements", () => {
 
 	describe("Edge Cases", () => {
 		it("should handle tags with no matching presets", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				unknown_key_xyz: "unknown_value_123",
 			};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			assert.strictEqual(result.matchedPresets.length, 0);
 		});
 
 		it("should handle single tag", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				building: "yes",
 			};
 
-			const result = await suggestImprovements(loader, tags);
+			const result = await suggestImprovements(tags);
 
 			assert.ok(result);
 			// Building=yes is very generic, should suggest more specific tags

--- a/tests/tools/validate-tag-collection.test.ts
+++ b/tests/tools/validate-tag-collection.test.ts
@@ -4,19 +4,17 @@ import deprecated from "@openstreetmap/id-tagging-schema/dist/deprecated.json" w
 	type: "json",
 };
 import { validateTagCollection } from "../../src/tools/validate-tag-collection.js";
-import { SchemaLoader } from "../../src/utils/schema-loader.js";
 
 describe("validateTagCollection", () => {
 	describe("Basic Functionality", () => {
 		it("should validate a collection of valid tags", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "parking",
 				parking: "surface",
 				capacity: "50",
 			};
 
-			const result = await validateTagCollection(loader, tags);
+			const result = await validateTagCollection(tags);
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, true);
@@ -27,13 +25,12 @@ describe("validateTagCollection", () => {
 		});
 
 		it("should detect errors in individual tags", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "",
 				parking: "surface",
 			};
 
-			const result = await validateTagCollection(loader, tags);
+			const result = await validateTagCollection(tags);
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, false);
@@ -43,8 +40,6 @@ describe("validateTagCollection", () => {
 		});
 
 		it("should detect deprecated tags in collection", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// Use first deprecated entry
 			const deprecatedEntry = deprecated[0];
 			const oldKey = Object.keys(deprecatedEntry.old)[0];
@@ -56,7 +51,7 @@ describe("validateTagCollection", () => {
 				amenity: "parking",
 			};
 
-			const result = await validateTagCollection(loader, tags);
+			const result = await validateTagCollection(tags);
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecatedCount, 1);
@@ -65,10 +60,9 @@ describe("validateTagCollection", () => {
 		});
 
 		it("should handle empty tag collection", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {};
 
-			const result = await validateTagCollection(loader, tags);
+			const result = await validateTagCollection(tags);
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, true);
@@ -78,13 +72,12 @@ describe("validateTagCollection", () => {
 		});
 
 		it("should aggregate warnings from individual tags", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				unknown_tag_key_12345: "value1",
 				another_unknown_key_67890: "value2",
 			};
 
-			const result = await validateTagCollection(loader, tags);
+			const result = await validateTagCollection(tags);
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, true);
@@ -94,12 +87,11 @@ describe("validateTagCollection", () => {
 
 	describe("Result Structure", () => {
 		it("should return correct result structure", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "parking",
 			};
 
-			const result = await validateTagCollection(loader, tags);
+			const result = await validateTagCollection(tags);
 
 			assert.ok(result);
 			assert.ok("valid" in result);
@@ -119,13 +111,12 @@ describe("validateTagCollection", () => {
 		});
 
 		it("should include individual tag validation results", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "parking",
 				access: "yes",
 			};
 
-			const result = await validateTagCollection(loader, tags);
+			const result = await validateTagCollection(tags);
 
 			assert.ok(result);
 			assert.ok(result.tagResults.amenity);
@@ -139,8 +130,6 @@ describe("validateTagCollection", () => {
 
 	describe("JSON Schema Validation", () => {
 		it("should validate collection with ALL deprecated tags from JSON (100% coverage)", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-
 			// CRITICAL: Test ALL deprecated entries - no Math.min, no sampling
 			let testedCount = 0;
 			let skippedCount = 0;
@@ -179,7 +168,7 @@ describe("validateTagCollection", () => {
 					tags.ref = "Test Ref";
 				}
 
-				const result = await validateTagCollection(loader, tags);
+				const result = await validateTagCollection(tags);
 
 				assert.ok(result, `Should validate collection for ${oldKey}=${oldValue}`);
 				assert.strictEqual(
@@ -202,13 +191,12 @@ describe("validateTagCollection", () => {
 
 	describe("Error Handling", () => {
 		it("should handle tags with empty keys", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				"": "value",
 				amenity: "parking",
 			};
 
-			const result = await validateTagCollection(loader, tags);
+			const result = await validateTagCollection(tags);
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, false);
@@ -216,13 +204,12 @@ describe("validateTagCollection", () => {
 		});
 
 		it("should handle tags with empty values", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			const tags = {
 				amenity: "",
 				parking: "surface",
 			};
 
-			const result = await validateTagCollection(loader, tags);
+			const result = await validateTagCollection(tags);
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, false);

--- a/tests/tools/validate-tag.test.ts
+++ b/tests/tools/validate-tag.test.ts
@@ -5,13 +5,11 @@ import deprecated from "@openstreetmap/id-tagging-schema/dist/deprecated.json" w
 };
 import fields from "@openstreetmap/id-tagging-schema/dist/fields.json" with { type: "json" };
 import { validateTag } from "../../src/tools/validate-tag.js";
-import { SchemaLoader } from "../../src/utils/schema-loader.js";
 
 describe("validateTag", () => {
 	describe("Basic Functionality", () => {
 		it("should validate a tag with valid key and value from options", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await validateTag(loader, "access", "yes");
+			const result = await validateTag("access", "yes");
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, true);
@@ -21,9 +19,8 @@ describe("validateTag", () => {
 		});
 
 		it("should validate a tag with valid key but value not in options", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			// building has options, but allows custom values (combo type)
-			const result = await validateTag(loader, "building", "custom_value");
+			const result = await validateTag("building", "custom_value");
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, true);
@@ -32,13 +29,12 @@ describe("validateTag", () => {
 		});
 
 		it("should detect deprecated tag", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			// Find a deprecated tag from the JSON
 			const deprecatedEntry = deprecated[0];
 			const oldKey = Object.keys(deprecatedEntry.old)[0];
 			const oldValue = deprecatedEntry.old[oldKey];
 
-			const result = await validateTag(loader, oldKey, oldValue);
+			const result = await validateTag(oldKey, oldValue);
 
 			assert.ok(result);
 			assert.strictEqual(result.deprecated, true);
@@ -47,8 +43,7 @@ describe("validateTag", () => {
 		});
 
 		it("should detect unknown key", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await validateTag(loader, "nonexistent_key_12345", "some_value");
+			const result = await validateTag("nonexistent_key_12345", "some_value");
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, true); // Unknown keys are allowed in OSM
@@ -57,9 +52,8 @@ describe("validateTag", () => {
 		});
 
 		it("should handle tag with no options field", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
 			// maxspeed has no options - any value is allowed
-			const result = await validateTag(loader, "maxspeed", "50");
+			const result = await validateTag("maxspeed", "50");
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, true);
@@ -134,8 +128,7 @@ describe("validateTag", () => {
 
 	describe("Error Handling", () => {
 		it("should handle empty key", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await validateTag(loader, "", "value");
+			const result = await validateTag("", "value");
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, false);
@@ -144,8 +137,7 @@ describe("validateTag", () => {
 		});
 
 		it("should handle empty value", async () => {
-			const loader = new SchemaLoader({ enableIndexing: true });
-			const result = await validateTag(loader, "amenity", "");
+			const result = await validateTag("amenity", "");
 
 			assert.ok(result);
 			assert.strictEqual(result.valid, false);


### PR DESCRIPTION
Remove SchemaLoader as a parameter from all tool handlers and import it directly as a singleton instance within tool files. This simplifies the architecture by eliminating parameter passing throughout the codebase.

Changes:
- Created singleton SchemaLoader instance in schema-loader.ts
- Updated ToolHandler type to remove loader parameter
- Refactored all 14 tool files to import schemaLoader directly
- Updated index.ts to remove SchemaLoader argument passing
- Updated all unit and integration tests
- Fixed linting warnings (unused imports)

Tests: All 313 unit tests and 120 integration tests pass