### PR TITLE
feat: add value descriptions to get_tag_values tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "~1.21.1",
-				"@openstreetmap/id-tagging-schema": "~6.7.3"
+				"@openstreetmap/id-tagging-schema": "^6.13.4"
 			},
 			"bin": {
 				"osm-tagging-mcp": "dist/index.js"
@@ -333,9 +333,9 @@
 			}
 		},
 		"node_modules/@openstreetmap/id-tagging-schema": {
-			"version": "6.7.3",
-			"resolved": "https://registry.npmjs.org/@openstreetmap/id-tagging-schema/-/id-tagging-schema-6.7.3.tgz",
-			"integrity": "sha512-2oYAXEqmnQd/J4iWYq0dp08Jd8XtOvyGm91fF9KJNbJW4IDRq9JgxAOxMizHG6cS9VrbZWndaMvoeIx94NiY8w==",
+			"version": "6.13.4",
+			"resolved": "https://registry.npmjs.org/@openstreetmap/id-tagging-schema/-/id-tagging-schema-6.13.4.tgz",
+			"integrity": "sha512-J9VTi2j1azlUxpdRQ2Cs7M+2V/gy6FRCLvI9uK5RvghLRXorryGBLbbn5OFldvsdpVMDSSrrsjrkix+xw5/f8w==",
 			"license": "ISC"
 		},
 		"node_modules/@sapphire/result": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 	],
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "~1.21.1",
-		"@openstreetmap/id-tagging-schema": "~6.7.3"
+		"@openstreetmap/id-tagging-schema": "^6.13.4"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.4",

--- a/tests/tools/get-tag-values.test.ts
+++ b/tests/tools/get-tag-values.test.ts
@@ -316,5 +316,58 @@ describe("get_tag_values", () => {
 				`Should return at least ${expectedOptions.size} values (from fields), got ${values.length}`,
 			);
 		});
+
+		it("should return descriptions for parking values from field.strings.options.[value].description", async () => {
+			// Test with "parking" which has descriptions in new schema format
+			const values = await getTagValues("parking");
+
+			assert.ok(values.length > 0, "Should have parking values");
+
+			// Verify that ALL parking values have descriptions
+			// In schema v6.13.4+, parking field has descriptions for all values
+			for (const item of values) {
+				assert.ok(
+					"description" in item &&
+						typeof item.description === "string" &&
+						item.description.length > 0,
+					`Parking value "${item.value}" should have a description. Got: ${JSON.stringify(item)}`,
+				);
+			}
+
+			// Verify specific examples from the schema
+			const surfaceValue = values.find((v) => v.value === "surface");
+			assert.ok(surfaceValue, "Should have 'surface' value");
+			assert.strictEqual(
+				surfaceValue.name,
+				"Surface",
+				"Surface value should have correct name/title",
+			);
+			assert.strictEqual(
+				surfaceValue.description,
+				"One level of parking on the ground.",
+				"Surface value should have correct description",
+			);
+
+			const undergroundValue = values.find((v) => v.value === "underground");
+			assert.ok(undergroundValue, "Should have 'underground' value");
+			assert.strictEqual(
+				undergroundValue.name,
+				"Underground",
+				"Underground value should have correct name/title",
+			);
+			assert.strictEqual(
+				undergroundValue.description,
+				"Underground parking.",
+				"Underground value should have correct description",
+			);
+
+			const carportsValue = values.find((v) => v.value === "carports");
+			assert.ok(carportsValue, "Should have 'carports' value");
+			assert.strictEqual(
+				carportsValue.description,
+				"Structure used to offer limited protection to vehicles, typically without walls.",
+				"Carports value should have correct description",
+			);
+		});
 	});
 });


### PR DESCRIPTION
Update @openstreetmap/id-tagging-schema from v6.7.3 to v6.13.4, which includes structured value information with descriptions.

Changes:
- Update schema package to v6.13.4 (latest version)
- Add test for parking field value descriptions
- Verify implementation handles new description format (title + description)
- Descriptions are sourced from field.strings.options.[value].description via translations (en.json)

Implementation:
- get_tag_values already had logic to handle object-based value translations
- Lines 79-85 in get-tag-values.ts handle both string and object formats
- When translationValue is object: uses .title as name, .description as description
- No code changes needed - test confirms existing implementation works correctly

Test coverage:
- 329 unit tests passing (313 pass, 16 skip)
- 122 integration tests passing (106 pass, 16 skip)
- New test validates all parking values have descriptions
- Verifies specific examples: surface, underground, carports

Example output for parking=surface:
{
  "value": "surface", "name": "Surface", "description": "One level of parking on the ground." }