### PR TITLE
Integrate OSM tagging schema MCP package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
 	"description": "MCP server for querying and validating OpenStreetMap tags",
 	"type": "module",
 	"main": "dist/index.js",
+	"module": "dist/index.js",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
 	"bin": {
 		"osm-tagging-mcp": "dist/index.js"
 	},


### PR DESCRIPTION
- Add `module` field pointing to dist/index.js
- Add `exports` field with conditional exports (types, import, default)
- Enables bundlephobia to analyze package bundle size
- Improves package.json compliance with modern ES module standards

TypeScript already generates type declarations (declaration: true), so the exports field correctly references dist/index.d.ts.