### PR TITLE
Fix Docker publish workflow and versioning

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # Tag "dev" for every merge to master (not for tags)
-            type=raw,value=dev,enable=${{ github.ref_type == 'branch' && github.ref_name == 'master' }}
+            # Tag "dev" for every push (merges to master + version tags)
+            type=raw,value=dev
             # Tag "latest" only for version tags vX.Y.Z
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
             # Tag vX.Y.Z (full version only, without vX.Y and vX)


### PR DESCRIPTION
- Tag 'dev' only for merges to master (not for version tags)
- Tag 'latest' only for version tags vX.Y.Z (not for master pushes)
- Tag 'vX.Y.Z' for version tags (full version only, without vX.Y and vX)

This ensures:
- Each PR merge to master updates 'dev' tag
- Each version release updates 'latest' tag
- Semantic versioning with full version numbers only