### PR TITLE
Update Cleanup System to Auto Mode

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,14 +1,19 @@
-name: Hourly Cleanup
+name: Auto Cleanup
 
 on:
   schedule:
     - cron: '0 * * * *'  # Every hour
   workflow_dispatch:      # Manual trigger for testing
     inputs:
-      min-versions-to-keep:
-        description: 'Minimum number of package versions to keep'
+      keep-dev-images:
+        description: 'Number of dev images to keep (-1 = never delete)'
         required: false
         default: '10'
+        type: number
+      keep-tagged-images:
+        description: 'Number of tagged images to keep (-1 = never delete)'
+        required: false
+        default: '-1'
         type: number
       retain-days:
         description: 'Number of days to retain workflow runs'
@@ -26,21 +31,48 @@ permissions:
   contents: read
 
 jobs:
-  cleanup-packages:
-    name: Clean Old Package Versions
+  cleanup-dev-packages:
+    name: Clean Old Dev Images
     runs-on: ubuntu-latest
+    # Skip if keep-dev-images is -1 (never delete)
+    # On schedule: runs with default (10). On manual: runs only if not -1
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.keep-dev-images != '-1') }}
     permissions:
       packages: write  # Required to delete package versions
       contents: read
 
     steps:
-      - name: Delete old package versions
+      - name: Delete old dev images
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
           package-name: 'osm-tagging-schema-mcp'
           package-type: 'container'
-          min-versions-to-keep: ${{ inputs.min-versions-to-keep || 10 }}
+          min-versions-to-keep: ${{ github.event.inputs.keep-dev-images || 10 }}
           delete-only-untagged-versions: 'false'
+          # Only delete versions tagged with 'dev'
+          ignore-versions: '^(?!.*dev).*$'
+          token: ${{ secrets.PAT_PACKAGES }}
+
+  cleanup-tagged-packages:
+    name: Clean Old Tagged Images
+    runs-on: ubuntu-latest
+    # Skip if keep-tagged-images is -1 (never delete)
+    # On schedule: skipped (default -1). On manual: runs only if not -1
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.keep-tagged-images != '-1' }}
+    permissions:
+      packages: write  # Required to delete package versions
+      contents: read
+
+    steps:
+      - name: Delete old tagged images
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: 'osm-tagging-schema-mcp'
+          package-type: 'container'
+          min-versions-to-keep: ${{ github.event.inputs.keep-tagged-images || 999999 }}
+          delete-only-untagged-versions: 'false'
+          # Only delete semantic version tags (exclude 'dev', 'latest')
+          ignore-versions: '^(dev|latest)$'
           token: ${{ secrets.PAT_PACKAGES }}
 
   cleanup-workflow-runs:
@@ -59,5 +91,5 @@ jobs:
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}
-          retain_days: ${{ inputs.retain-days || 3 }}
-          keep_minimum_runs: ${{ inputs.keep-minimum-runs || 30 }}
+          retain_days: ${{ github.event.inputs.retain-days || 3 }}
+          keep_minimum_runs: ${{ github.event.inputs.keep-minimum-runs || 30 }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,7 +374,7 @@ tests/                               # Test files (TDD - one test file per tool)
     ├── publish.yml                  # ✅ npm publishing
     ├── security.yml                 # ✅ Security scanning
     ├── codeql.yml                   # ✅ Code scanning
-    ├── cleanup.yml                  # ✅ Package cleanup
+    ├── cleanup.yml                  # ✅ Auto cleanup (dev/tagged packages)
     └── dependency-review.yml        # ✅ Dependency review
 docs/                                # User documentation
     ├── installation.md              # ✅ Installation guide


### PR DESCRIPTION
…ged handling

Changes:
- Rename workflow from "Hourly Cleanup" to "Auto Cleanup"
- Split package cleanup into two separate jobs:
  * cleanup-dev-packages: Clean old dev images (default: keep 10)
  * cleanup-tagged-packages: Clean old tagged images (default: keep all, -1)
- Add separate configuration for dev and tagged images
- Support -1 value for "never delete" for both image types
- On schedule: only dev images cleaned, tagged images preserved
- On manual trigger: both can be cleaned with custom settings
- Update CLAUDE.md to reflect new cleanup automation

Default behavior:
- Dev images: Keep last 10 (runs hourly)
- Tagged images: Never delete (default -1, manual trigger only)