### PR TITLE
feat: Remove SSE transport support - HTTP only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,10 @@
 # Transport Configuration
-# Choose between 'stdio' (default), 'http', or 'sse'
+# Choose between 'stdio' (default) or 'http'
 # - stdio: Standard input/output (for MCP clients like Claude Code/Desktop)
-# - http: HTTP Streamable transport (recommended for web clients)
-# - sse: Server-Sent Events transport (alias for http, kept for compatibility)
+# - http: HTTP Streamable transport (for web clients)
 TRANSPORT=stdio
 
-# HTTP/SSE Transport Configuration (only used when TRANSPORT=http or TRANSPORT=sse)
+# HTTP Transport Configuration (only used when TRANSPORT=http)
 PORT=3000
 HOST=0.0.0.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,7 @@ tests/                               # Test files (TDD - one test file per tool)
 └── integration/                     # Integration tests (one file per tool)
     ├── helpers.ts                   # ✅ Shared test utilities
     ├── server-init.test.ts          # ✅ Server initialization tests
-    ├── sse-transport.test.ts        # ✅ HTTP/SSE transport tests
+    ├── http-transport.test.ts       # ✅ HTTP transport tests
     ├── get-preset-details.test.ts   # ✅ Present
     ├── get-tag-values.test.ts       # ✅ Present
     ├── search-presets.test.ts       # ✅ Present
@@ -1082,7 +1082,7 @@ Currently: Validates `field.options` only, not `field.type` (number/url/email).
 - ✅ **Docker Support**: Multi-stage builds, multi-arch (amd64/arm64), image signing (Cosign)
 - ✅ **Container Registry**: Images published to GitHub Container Registry (ghcr.io)
 - ✅ **Security Scanning**: Trivy vulnerability scanning, security reports
-- ✅ **Transport Protocols**: stdio (default), HTTP/SSE for web clients
+- ✅ **Transport Protocols**: stdio (default), HTTP for web clients
 - ✅ **Docker Compose**: Production, development, and test configurations
 - ✅ **Health Checks**: `/health` (liveness) and `/ready` (readiness) endpoints
 
@@ -1353,7 +1353,7 @@ npx @modelcontextprotocol/inspector docker run -i --rm --pull always \
 
 **Goal**: Support multiple transport protocols beyond stdio for diverse deployment scenarios.
 
-**Status**: ✅ **COMPLETED** - HTTP Streamable transport implemented with SSE support
+**Status**: ✅ **COMPLETED** - HTTP Streamable transport implemented
 
 **Supported Transports**:
 
@@ -1369,19 +1369,14 @@ npx @modelcontextprotocol/inspector docker run -i --rm --pull always \
 - Stateful session management with UUID session IDs
 - Compatible with web browsers and HTTP clients
 - Use case: Web applications, API gateways, scalable deployments
-- **Configuration**: `TRANSPORT=http` (recommended)
-
-**c) SSE (Server-Sent Events)** ✅
-- Alias for HTTP transport (backward compatibility)
-- Same implementation as HTTP transport
-- **Configuration**: `TRANSPORT=sse` (legacy, kept for compatibility)
+- **Configuration**: `TRANSPORT=http`
 
 **Transport Configuration** ✅:
 ```bash
 # Environment variables
-TRANSPORT=stdio|http|sse    # Default: stdio
-PORT=3000                   # Default: 3000 (HTTP/SSE only)
-HOST=0.0.0.0                # Default: 0.0.0.0 (HTTP/SSE only)
+TRANSPORT=stdio|http    # Default: stdio
+PORT=3000               # Default: 3000 (HTTP only)
+HOST=0.0.0.0            # Default: 0.0.0.0 (HTTP only)
 ```
 
 **Usage Examples** ✅:
@@ -1389,20 +1384,15 @@ HOST=0.0.0.0                # Default: 0.0.0.0 (HTTP/SSE only)
 # stdio transport (default)
 npx @gander-tools/osm-tagging-schema-mcp
 
-# HTTP transport (recommended)
+# HTTP transport
 TRANSPORT=http npx @gander-tools/osm-tagging-schema-mcp
-
-# SSE transport (legacy, same as http)
-TRANSPORT=sse npx @gander-tools/osm-tagging-schema-mcp
 
 # HTTP with custom port
 TRANSPORT=http PORT=8080 npx @gander-tools/osm-tagging-schema-mcp
 
 # npm scripts
 npm run start:http  # Start with HTTP transport on port 3000
-npm run start:sse   # Start with SSE transport on port 3000 (legacy)
 npm run dev:http    # Development mode with HTTP transport
-npm run dev:sse     # Development mode with SSE transport (legacy)
 
 # Docker with HTTP (using latest stable)
 docker run -e TRANSPORT=http -e PORT=3000 -p 3000:3000 \
@@ -1414,14 +1404,14 @@ docker run -e TRANSPORT=http -e PORT=3000 -p 3000:3000 \
 ```
 
 **Implementation Details** ✅:
-- Uses `StreamableHTTPServerTransport` from MCP SDK (not deprecated `SSEServerTransport`)
+- Uses `StreamableHTTPServerTransport` from MCP SDK
 - Session management: Tracks multiple sessions with UUID-based session IDs
 - Session lifecycle: `onsessioninitialized` and `onsessionclosed` callbacks
-- HTTP request routing: GET for SSE streams, POST for JSON-RPC messages, DELETE for session termination
+- HTTP request routing: GET for event streams, POST for JSON-RPC messages, DELETE for session termination
 - Error handling: Graceful error responses with proper HTTP status codes
 - **Keep-alive**: Automatically sends ping messages (`:ping\n\n`) every 15 seconds to prevent connection timeouts
-  - Wrapper function `wrapResponseWithKeepAlive()` intercepts SSE stream setup
-  - Detects SSE streams via `Content-Type: text/event-stream` header
+  - Wrapper function `wrapResponseWithKeepAlive()` intercepts event stream setup
+  - Detects event streams via `Content-Type: text/event-stream` header
   - Starts interval timer for periodic ping messages
   - Cleans up interval on connection close or response end
   - Configurable interval for testing purposes (default: 15000ms)
@@ -1432,7 +1422,7 @@ docker run -e TRANSPORT=http -e PORT=3000 -p 3000:3000 \
 - StreamableHTTPServerTransport integration tests
 - Session ID generation and tracking tests
 - Keep-alive functionality tests (ping messages, cleanup on close)
-- 14 SSE transport tests passing (100% coverage)
+- 13 HTTP transport tests passing (100% coverage)
 
 **Benefits** ✅:
 - Flexibility in deployment architecture

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ EXPOSE 3000
 # Health check - uses /health endpoint when HTTP transport is enabled
 # For stdio transport, falls back to basic node check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD if [ "$TRANSPORT" = "http" ] || [ "$TRANSPORT" = "sse" ]; then \
+    CMD if [ "$TRANSPORT" = "http" ]; then \
         node -e "require('http').get('http://localhost:' + (process.env.PORT || '3000') + '/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"; \
     else \
         node -e "console.log('OK')" || exit 1; \

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -155,7 +155,6 @@
 **Transport & Deployment:**
 - ✅ stdio transport (default for CLI/desktop)
 - ✅ HTTP Streamable transport (web clients)
-- ✅ SSE transport (legacy alias)
 - ✅ Docker Compose configurations
 - ✅ Health check endpoints (/health, /ready)
 - ✅ Resource limits and security hardening

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,14 +301,13 @@ The server supports the following environment variables for configuration:
 
 **`TRANSPORT`** - Select transport protocol (default: `stdio`)
 - `stdio`: Standard input/output (default, for MCP clients like Claude Code/Desktop)
-- `http`: HTTP Streamable transport (recommended for web applications and HTTP clients)
+- `http`: HTTP Streamable transport (for web applications and HTTP clients)
   - Automatically sends keep-alive ping messages every 15 seconds to prevent connection timeouts
   - Suitable for deployment behind proxies, load balancers, and firewalls
-- `sse`: Server-Sent Events transport (alias for `http`, kept for backward compatibility)
 
-**`PORT`** - HTTP server port when using HTTP/SSE transport (default: `3000`)
+**`PORT`** - HTTP server port when using HTTP transport (default: `3000`)
 
-**`HOST`** - HTTP server host when using HTTP/SSE transport (default: `0.0.0.0`)
+**`HOST`** - HTTP server host when using HTTP transport (default: `0.0.0.0`)
 
 **Examples:**
 
@@ -316,11 +315,8 @@ The server supports the following environment variables for configuration:
 # Run with stdio (default)
 npx @gander-tools/osm-tagging-schema-mcp
 
-# Run with HTTP transport (recommended)
+# Run with HTTP transport
 TRANSPORT=http npx @gander-tools/osm-tagging-schema-mcp
-
-# Run with SSE transport (legacy, same as http)
-TRANSPORT=sse npx @gander-tools/osm-tagging-schema-mcp
 
 # Run with HTTP on custom port and host
 TRANSPORT=http PORT=8080 HOST=127.0.0.1 npx @gander-tools/osm-tagging-schema-mcp
@@ -329,9 +325,7 @@ TRANSPORT=http PORT=8080 HOST=127.0.0.1 npx @gander-tools/osm-tagging-schema-mcp
 **Using with npm scripts:**
 ```bash
 npm run start:http      # Start with HTTP transport (port 3000)
-npm run start:sse       # Start with SSE transport (port 3000, legacy)
 npm run dev:http        # Development mode with HTTP transport
-npm run dev:sse         # Development mode with SSE transport (legacy)
 ```
 
 **Docker with HTTP transport:**
@@ -414,7 +408,7 @@ npx @modelcontextprotocol/inspector --transport http --server-url http://localho
 NODE_OPTIONS="--max-old-space-size=512" npx @gander-tools/osm-tagging-schema-mcp
 
 # Combine with transport configuration
-TRANSPORT=sse PORT=3000 NODE_OPTIONS="--max-old-space-size=512" \
+TRANSPORT=http PORT=3000 NODE_OPTIONS="--max-old-space-size=512" \
 DEBUG="mcp:*" npx @gander-tools/osm-tagging-schema-mcp
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -177,7 +177,7 @@ Edit the `environment` section in `docker-compose.yml`:
 ```yaml
 environment:
   # Transport protocol
-  TRANSPORT: http        # Options: stdio, http, sse
+  TRANSPORT: http        # Options: stdio, http
 
   # HTTP server configuration
   PORT: 3000             # HTTP port (default: 3000)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -718,29 +718,17 @@ docker run -e TRANSPORT=http -e PORT=3000 -p 3000:3000 \
 ```
 
 **Environment Variables:**
-- `TRANSPORT` - Transport type: `stdio` (default), `http`, or `sse`
+- `TRANSPORT` - Transport type: `stdio` (default) or `http`
 - `PORT` - HTTP server port (default: 3000)
 - `HOST` - HTTP server host (default: 0.0.0.0)
 - `LOG_LEVEL` - Logging level: `SILENT`, `ERROR`, `WARN`, `INFO`, `DEBUG`
 
 **HTTP Endpoints:**
-- `GET /sse` - Server-Sent Events stream for MCP messages
-- `POST /sse` - Send JSON-RPC messages to MCP server
-- `DELETE /sse/:sessionId` - Close a session
+- `GET /mcp` - Server-Sent Events stream for MCP messages
+- `POST /mcp` - Send JSON-RPC messages to MCP server
+- `DELETE /mcp/:sessionId` - Close a session
 - `GET /health` - Liveness probe (server status)
 - `GET /ready` - Readiness probe (schema loaded status)
-
-### SSE Transport (Legacy)
-
-SSE transport is a legacy alias for HTTP transport. Use `TRANSPORT=http` for new deployments:
-
-```bash
-# Legacy SSE transport (same as http)
-TRANSPORT=sse PORT=3000 npx @gander-tools/osm-tagging-schema-mcp
-
-# Recommended: Use http instead
-TRANSPORT=http PORT=3000 npx @gander-tools/osm-tagging-schema-mcp
-```
 
 ### Docker Compose Deployment
 

--- a/package.json
+++ b/package.json
@@ -18,11 +18,9 @@
 	"scripts": {
 		"dev": "tsx --watch src/index.ts",
 		"dev:http": "TRANSPORT=http tsx --watch src/index.ts",
-		"dev:sse": "TRANSPORT=sse tsx --watch src/index.ts",
 		"build": "tsc",
 		"start": "node dist/index.js",
 		"start:http": "TRANSPORT=http node dist/index.js",
-		"start:sse": "TRANSPORT=sse node dist/index.js",
 		"test": "node --import tsx --test tests/**/*.test.ts",
 		"test:unit": "node --import tsx --test tests/**/*.test.ts --exclude tests/integration/**",
 		"test:integration": "node --import tsx --test tests/integration/**/*.test.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export function createServer(): McpServer {
  * Configuration for transport selection
  */
 interface TransportConfig {
-	type: "stdio" | "sse" | "http";
+	type: "stdio" | "http";
 	port: number;
 	host: string;
 	corsOrigins: string[];
@@ -48,12 +48,7 @@ interface TransportConfig {
  */
 function getTransportConfig(): TransportConfig {
 	const transportEnv = process.env.TRANSPORT?.toLowerCase() || "stdio";
-	// Support both 'sse' and 'http' for StreamableHTTPServerTransport
-	// 'sse' is kept for backward compatibility
-	const type = (transportEnv === "sse" || transportEnv === "http" ? transportEnv : "stdio") as
-		| "stdio"
-		| "sse"
-		| "http";
+	const type = (transportEnv === "http" ? "http" : "stdio") as "stdio" | "http";
 	const port = Number.parseInt(process.env.PORT || "3000", 10);
 	const host = process.env.HOST || "0.0.0.0";
 
@@ -348,7 +343,7 @@ async function main() {
 	logger.info("Schema preloaded successfully", "main");
 
 	// Start appropriate transport
-	if (config.type === "sse" || config.type === "http") {
+	if (config.type === "http") {
 		await startHttpServer(server, config);
 	} else {
 		const transport = new StdioServerTransport();

--- a/tests/integration/http-transport.test.ts
+++ b/tests/integration/http-transport.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import http from "node:http";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
-describe("SSE Transport Integration Tests", () => {
+describe("HTTP Transport Integration Tests", () => {
 	describe("Environment Configuration", () => {
 		let originalEnv: NodeJS.ProcessEnv;
 
@@ -18,11 +18,6 @@ describe("SSE Transport Integration Tests", () => {
 			delete process.env.TRANSPORT;
 			const transport = process.env.TRANSPORT || "stdio";
 			assert.strictEqual(transport, "stdio");
-		});
-
-		it("should use sse transport when TRANSPORT=sse", () => {
-			process.env.TRANSPORT = "sse";
-			assert.strictEqual(process.env.TRANSPORT, "sse");
 		});
 
 		it("should use http transport when TRANSPORT=http", () => {
@@ -145,7 +140,7 @@ describe("SSE Transport Integration Tests", () => {
 			});
 		});
 
-		it("should handle GET requests to /mcp endpoint for SSE", async () => {
+		it("should handle GET requests to /mcp endpoint for event streams", async () => {
 			let requestReceived = false;
 
 			server = http.createServer((req, res) => {
@@ -290,7 +285,7 @@ describe("SSE Transport Integration Tests", () => {
 			// We expect this to not throw
 			await transport.handleRequest(mockReq, mockRes, initRequest);
 
-			// The transport should accept the request (status 200 for SSE stream)
+			// The transport should accept the request (status 200 for HTTP stream)
 			assert.ok(
 				statusCode === 200 || statusCode === 202,
 				`Should return 200 or 202, got ${statusCode}`,
@@ -523,7 +518,7 @@ describe("SSE Transport Integration Tests", () => {
 			}
 		});
 
-		it("should send keep-alive ping messages for SSE streams", { timeout: 5000 }, async () => {
+		it("should send keep-alive ping messages for event streams", { timeout: 5000 }, async () => {
 			// Import the wrapper function from index.ts
 			const { wrapResponseWithKeepAlive } = await import("../../src/index.js");
 
@@ -538,7 +533,7 @@ describe("SSE Transport Integration Tests", () => {
 					// Wrap response with keep-alive functionality (1s interval for testing)
 					const wrappedRes = wrapResponseWithKeepAlive(res, req, testIntervalMs);
 
-					// Simulate SSE stream setup
+					// Simulate event stream setup
 					wrappedRes.writeHead(200, {
 						"Content-Type": "text/event-stream",
 						"Cache-Control": "no-cache",
@@ -597,7 +592,7 @@ describe("SSE Transport Integration Tests", () => {
 								);
 								assert.ok(
 									receivedData.includes(":ping"),
-									"Should receive ping messages in SSE format",
+									"Should receive ping messages in event stream format",
 								);
 
 								resolve();


### PR DESCRIPTION
Removes the legacy SSE transport alias, keeping only HTTP transport.

Changes:
- src/index.ts: Remove 'sse' from TransportConfig type and parsing logic
- package.json: Remove dev:sse and start:sse scripts
- tests: Rename sse-transport.test.ts → http-transport.test.ts
- docs: Update all documentation to remove SSE references
- Dockerfile: Remove SSE check from HEALTHCHECK
- .env.example: Update transport options

HTTP transport remains fully functional and unchanged.

All tests passing: 344/344 ✅