### PR TITLE
Fix Docker publish latest tag on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,13 +44,13 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}},priority=1000
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }},priority=1000
             type=edge,enable={{is_default_branch}},priority=900
             type=ref,event=branch,priority=800
             type=ref,event=pr,priority=700
-            type=semver,pattern={{major}},enable={{is_default_branch}},priority=600
-            type=semver,pattern={{major}}.{{minor}},enable={{is_default_branch}},priority=500
-            type=semver,pattern={{major}}.{{minor}}.{{patch}},enable={{is_default_branch}},priority=400
+            type=semver,pattern={{major}},priority=600
+            type=semver,pattern={{major}}.{{minor}},priority=500
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},priority=400
 
       - name: Build and push Docker image
         id: build-and-push


### PR DESCRIPTION
Changes:
- Modified docker.yml workflow to create 'latest' tag only for version tags (v*.*.*)
- Previously 'latest' was created on every push to master
- Removed redundant 'enable' conditions from semver tags (they only work on tags anyway)

Impact:
- 'latest' tag: Only created on GitHub Release (stable versions)
- 'edge' tag: Still created on every master branch push (development versions)
- Semantic version tags (X, X.Y, X.Y.Z): Only created on GitHub Release

Resolves the issue where 'latest' was incorrectly updated with every master push.