### PR TITLE
Send webhook notification on Docker image publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,3 +93,48 @@ jobs:
           echo "Signing image with digest: ${DIGEST}"
           cosign sign --yes --recursive \
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
+
+      # Send webhook notification when 'latest' tag is published
+      - name: Send webhook for latest tag publication
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          WEBHOOK_URL: ${{ secrets.DOCKER_PUBLISH_LATEST_WEBHOOK }}
+          IMAGE_DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: |
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo "Warning: DOCKER_PUBLISH_LATEST_WEBHOOK secret not set, skipping webhook"
+            exit 0
+          fi
+
+          echo "Sending webhook notification for latest tag publication..."
+
+          # Prepare webhook payload
+          PAYLOAD=$(cat <<EOF
+          {
+            "event": "docker_publish_latest",
+            "repository": "${{ github.repository }}",
+            "image": "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",
+            "tag": "latest",
+            "version": "${{ github.ref_name }}",
+            "digest": "${IMAGE_DIGEST}",
+            "commit": "${{ github.sha }}",
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "actor": "${{ github.actor }}"
+          }
+          EOF
+          )
+
+          # Send POST request to webhook
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: GitHub-Actions" \
+            -d "$PAYLOAD" \
+            "$WEBHOOK_URL")
+
+          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+            echo "✓ Webhook sent successfully (HTTP $HTTP_CODE)"
+          else
+            echo "✗ Webhook failed with HTTP $HTTP_CODE"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -844,6 +844,51 @@ Each Docker image includes:
 - ✅ **SARIF Reports**: Security scan results in GitHub Security tab
 - ✅ **Verification**: Users can verify image authenticity
 
+#### Webhook Notification for Latest Tag
+
+When a Docker image with the `latest` tag is published (i.e., when a version tag like `v1.0.0` is pushed), a webhook notification can be sent to a configured endpoint.
+
+**Setup:**
+
+1. **Configure Webhook URL:**
+   - Go to: Repository → Settings → Secrets and variables → Actions
+   - Click "New repository secret"
+   - Name: `DOCKER_PUBLISH_LATEST_WEBHOOK`
+   - Value: Your webhook endpoint URL (e.g., `https://example.com/webhook`)
+
+2. **Webhook Payload:**
+   The webhook sends a POST request with JSON payload:
+   ```json
+   {
+     "event": "docker_publish_latest",
+     "repository": "gander-tools/osm-tagging-schema-mcp",
+     "image": "ghcr.io/gander-tools/osm-tagging-schema-mcp",
+     "tag": "latest",
+     "version": "v1.0.0",
+     "digest": "sha256:...",
+     "commit": "abc123...",
+     "timestamp": "2025-11-19T12:00:00Z",
+     "actor": "github-username"
+   }
+   ```
+
+3. **Webhook Headers:**
+   - `Content-Type: application/json`
+   - `User-Agent: GitHub-Actions`
+
+**Testing:**
+
+The webhook will only be sent when:
+- A version tag is pushed (e.g., `v1.0.0`)
+- The `latest` tag is created for the Docker image
+- The secret `DOCKER_PUBLISH_LATEST_WEBHOOK` is configured
+
+**Troubleshooting:**
+
+- If the webhook secret is not set, the step will be skipped with a warning
+- If the webhook returns HTTP status outside 200-299 range, the workflow will fail
+- Check GitHub Actions logs for webhook delivery status
+
 #### Verifying Docker Images
 
 After images are published, verify security features:


### PR DESCRIPTION
Add POST webhook notification when Docker image with 'latest' tag is published to GHCR. Webhook is triggered only on version tag push (e.g., v1.0.0).

Changes:
- Add webhook step in .github/workflows/docker.yml
- Send POST request to $DOCKER_PUBLISH_LATEST_WEBHOOK
- Include comprehensive JSON payload with image metadata
- Graceful handling when webhook secret not configured
- Add documentation in CONTRIBUTING.md

Webhook payload includes:
- event, repository, image details
- tag (latest), version, digest
- commit SHA, timestamp, actor

Configuration:
- Set DOCKER_PUBLISH_LATEST_WEBHOOK secret in repository settings
- Webhook only sent for version tags (v*.*.*)
- HTTP 200-299 required for success