### PR TITLE
Update README with current package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # OpenStreetMap Tagging Schema MCP Server
 
 [![Test](https://img.shields.io/github/actions/workflow/status/gander-tools/osm-tagging-schema-mcp/test.yml?branch=master&label=tests)](https://github.com/gander-tools/osm-tagging-schema-mcp/actions/workflows/test.yml)
-[![Tests](https://img.shields.io/badge/tests-424%20passing-brightgreen)](https://github.com/gander-tools/osm-tagging-schema-mcp/actions/workflows/test.yml)
 [![Fuzzing](https://img.shields.io/github/actions/workflow/status/gander-tools/osm-tagging-schema-mcp/fuzz.yml?branch=master&label=fuzzing)](https://github.com/gander-tools/osm-tagging-schema-mcp/actions/workflows/fuzz.yml)
 [![Docker](https://img.shields.io/github/actions/workflow/status/gander-tools/osm-tagging-schema-mcp/docker.yml?branch=master&label=docker)](https://github.com/gander-tools/osm-tagging-schema-mcp/actions/workflows/docker.yml)
 [![npm version](https://img.shields.io/npm/v/@gander-tools/osm-tagging-schema-mcp)](https://www.npmjs.com/package/@gander-tools/osm-tagging-schema-mcp)
@@ -97,8 +96,8 @@ The Inspector UI will open in your browser at `http://localhost:6274` with a vis
 ## Development
 
 Built with **Test-Driven Development (TDD)** and **Property-Based Fuzzing**:
-- 424 tests (319 unit + 105 integration) with 100% pass rate
-- 22 fuzz tests (~15,000 test cases per run with fast-check)
+- Comprehensive test suite (unit + integration) with 100% pass rate
+- Property-based fuzz tests (~15,000 test cases per run with fast-check)
 - Continuous fuzzing in CI/CD (weekly schedule + on every push/PR)
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@gander-tools/osm-tagging-schema-mcp",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@gander-tools/osm-tagging-schema-mcp",
-			"version": "0.1.0",
+			"version": "1.0.0",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"dependencies": {
@@ -29,7 +29,8 @@
 				"zod": "^3.24.1"
 			},
 			"engines": {
-				"node": ">=22.0.0"
+				"node": ">=22.0.0",
+				"npm": ">=11.5.1"
 			}
 		},
 		"node_modules/@bcoe/v8-coverage": {


### PR DESCRIPTION
- Remove static "424 passing" badge (replace with dynamic GitHub Actions status)
- Remove specific test counts from Development section
- Keep only pass/fail status badges that auto-update
- Update package-lock.json from npm install