### PR TITLE
fix: change postinstall to prepare for lefthook

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"format": "biome format --write .",
 		"check": "biome check --write .",
 		"typecheck": "tsc --noEmit",
-		"postinstall": "lefthook install",
+		"prepare": "lefthook install",
 		"release:dry": "cliff-jumper --dry-run",
 		"release": "cliff-jumper",
 		"release:push": "cliff-jumper --push-tag"


### PR DESCRIPTION
The postinstall script was running lefthook install every time users installed the package, causing failures in non-git directories.

Changed to prepare script which only runs during development (npm install in the repository itself), not when users install the published package.

Fixes npm install error: "fatal: not a git repository"