### PR TITLE
Fix git tag push error

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -81,14 +81,14 @@ jobs:
       - name: Generate changelog
         run: |
           # Generate changelog using git-cliff
-          npx git-cliff --tag v${{ steps.get_version.outputs.new_version }} --output CHANGELOG.md
+          npx git-cliff --tag ${{ steps.get_version.outputs.new_version }} --output CHANGELOG.md
           echo "Changelog generated"
 
       - name: Commit version bump and changelog
         run: |
           git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore(release): release osm-tagging-schema-mcp@${{ steps.get_version.outputs.new_version }}"
-          git tag v${{ steps.get_version.outputs.new_version }}
+          git tag ${{ steps.get_version.outputs.new_version }}
           echo "Version bump and changelog committed"
 
       - name: Push release branch


### PR DESCRIPTION
The workflow was creating tags with double 'v' prefix (vv1.0.1) because:
- Line 78 sets new_version=v${NEW_VERSION} (includes 'v')
- Lines 84 and 91 were adding another 'v' prefix

This caused git push to fail because the tag being pushed (v1.0.1) didn't match the tag that was created (vv1.0.1).

Fixed by removing the extra 'v' prefix from:
- Line 84: git-cliff --tag parameter
- Line 91: git tag command