### PR TITLE
[CLAUDE] Add GitHub Action for automatic PR creation from claude/* branches

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -96,16 +96,17 @@ git push origin claude/add-new-feature-abc123
 
 The workflow automatically:
 1. ✅ Detects the branch push
-2. ✅ Extracts feature description from branch name
-3. ✅ Creates a PR targeting the default branch
+2. ✅ Creates a PR with title: `[CLAUDE] <first commit title>`
+3. ✅ Targets the default branch
 4. ✅ Includes recent commits in PR description
 5. ✅ Adds labels: `auto-created`, `claude-branch`
 
 **Branch naming format:** `claude/<feature-description>-<session-id>`
 
 Example: `claude/improve-validation-01Y1fZwRf7bd`
-- Feature: "Improve Validation"
 - Session ID: `01Y1fZwRf7bd`
+- First commit: "Improve tag validation logic"
+- **PR Title**: `[CLAUDE] Improve tag validation logic`
 
 #### Troubleshooting
 

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -51,6 +51,10 @@ jobs:
           BASE_BRANCH="${{ steps.branch.outputs.base }}"
           COMMITS=$(git log origin/${BASE_BRANCH}..HEAD --pretty=format:"- %s" | head -n 10)
 
+          # Get first commit title for PR title
+          FIRST_COMMIT_TITLE=$(git log origin/${BASE_BRANCH}..HEAD --pretty=format:"%s" | tail -n 1)
+          echo "first_title=${FIRST_COMMIT_TITLE}" >> $GITHUB_OUTPUT
+
           # Escape newlines for GitHub output
           COMMITS="${COMMITS//'%'/'%25'}"
           COMMITS="${COMMITS//$'\n'/'%0A'}"
@@ -72,7 +76,7 @@ jobs:
           if gh pr create \
             --base "${{ steps.branch.outputs.base }}" \
             --head "${{ steps.branch.outputs.name }}" \
-            --title "[${{ steps.branch.outputs.feature }}] Auto-created PR from claude branch" \
+            --title "[CLAUDE] ${{ steps.commits.outputs.first_title }}" \
             --body "$(cat <<'EOF'
           ## 🤖 Auto-created Pull Request
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1678,7 +1678,7 @@ This project follows an **intent-based workflow** where development is organized
    - Branch naming: `claude/<feature-description>-<session-id>`
    - One branch per feature (not per command)
    - Master branch is protected - all changes must go through feature branches
-   - **Auto-PR**: Pushing to `claude/*` branches automatically creates a Pull Request (see `.github/workflows/auto-pr.yml`)
+   - **Auto-PR**: Pushing to `claude/*` branches automatically creates a Pull Request with title `[CLAUDE] <first commit title>` (see `.github/workflows/auto-pr.yml`)
 
 3. **Feature Branch Lifecycle**
    - Once a feature branch is created and pushed, continue using it for all related changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,8 +218,8 @@ git push origin claude/add-new-feature-abc123
 
 The auto-PR workflow will:
 - ✅ Detect the `claude/*` branch push
-- ✅ Extract feature description from branch name
-- ✅ Create a PR targeting the default branch (main/master)
+- ✅ Create a PR with title: `[CLAUDE] <first commit title>`
+- ✅ Target the default branch (main/master)
 - ✅ Include recent commits in the PR description
 - ✅ Add labels: `auto-created`, `claude-branch`
 - ✅ Skip creation if a PR already exists
@@ -227,8 +227,9 @@ The auto-PR workflow will:
 **Branch naming format:** `claude/<feature-description>-<session-id>`
 
 Example: `claude/add-tag-validation-01Y1fZwRf7bd`
-- Feature: "Add Tag Validation"
 - Session ID: `01Y1fZwRf7bd`
+- First commit: "Add tag validation for OSM keys"
+- **PR Title**: `[CLAUDE] Add tag validation for OSM keys`
 
 **⚠️ Setup Required:**
 


### PR DESCRIPTION
- Create .github/workflows/auto-pr.yml workflow
- Automatically creates PRs when pushing to claude/* branches
- Extracts feature description from branch name
- Includes commit history in PR description
- Adds auto-created and claude-branch labels
- Checks for existing PRs to avoid duplicates
- Uses pinned action version (actions/checkout@v4.3.1)

Documentation updates:
- CONTRIBUTING.md: Added automatic PR creation section
- CLAUDE.md: Updated CI/CD pipeline and workflow principles

Resolves the need for manual PR creation for AI-assisted development workflow.