### PR TITLE
ci: Remove on-demand build triggers from workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -46,13 +46,6 @@ on:
         type: boolean
         default: true
 
-  # Trigger when specific label is added to PR (on-demand builds)
-  pull_request:
-    types: [labeled]
-
-  # Trigger via PR comment (on-demand builds)
-  issue_comment:
-    types: [created]
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Removed on-demand build triggers for pull requests and issue comments.