### PR TITLE
fix: Explicitly include dist/ in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@ node_modules/
 
 # Build output (Note: dist/ is NOT excluded - it's provided by workflow)
 # dist/ must be available for Dockerfile.release (pre-built by workflow)
+!dist/
 build/
 *.tsbuildinfo
 


### PR DESCRIPTION
## 📝 Commits

- fix: Explicitly include dist/ in Docker build context