### PR TITLE
ci: Remove versioning strategy from release config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
 		".": {
 			"release-type": "node",
 			"package-name": "@gander-tools/osm-tagging-schema-mcp",
-			"versioning": "always-bump-minor",
 			"changelog-sections": [
 				{
 					"type": "feat",


### PR DESCRIPTION
Removed the versioning strategy from the config.