### PR TITLE
chore(ci): standardize Node.js version to 24 and npm to 11.6.4 across all workflows

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -63,7 +63,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 24.x
+          node-version: 24
+
+      - name: Install npm 11.6.4
+        run: npm install -g npm@11.6.4
 
       - name: Install dependencies
         run: npm ci
@@ -88,7 +91,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 24.x
+          node-version: 24
+
+      - name: Install npm 11.6.4
+        run: npm install -g npm@11.6.4
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -244,9 +244,9 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install npm 11.5.1 (non-release builds)
+      - name: Install npm 11.6.4 (non-release builds)
         if: needs.extract-version.outputs.is-release == 'false'
-        run: npm install -g npm@11.5.1
+        run: npm install -g npm@11.6.4
 
       - name: Install dependencies (non-release builds)
         if: needs.extract-version.outputs.is-release == 'false'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 24.x
+          node-version: 24
 
       # npm must be newer than 11.5.1 for Node 24 compatibility
       - name: Install npm 11.6.4
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 24.x
+          node-version: 24
 
       # npm must be newer than 11.5.1 for Node 24 compatibility
       - name: Install npm 11.6.4


### PR DESCRIPTION
## 📝 Commits

- chore(ci): standardize Node.js version to 24 and npm to 11.6.4 across all workflows