### PR TITLE
docs: add missing CORS_ORIGINS to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,10 @@ TRANSPORT=stdio
 PORT=3000
 HOST=0.0.0.0
 
+# CORS Origins (only used when TRANSPORT=http)
+# Comma-separated list of allowed origins, or "*" for all origins
+# Default: http://localhost:6274,https://mcp.ziziyi.com
+CORS_ORIGINS=http://localhost:6274,https://mcp.ziziyi.com
+
 # Logging Configuration
 LOG_LEVEL=info


### PR DESCRIPTION
## 📝 Commits

- docs: add missing CORS_ORIGINS to .env.example