### PR TITLE
fix: add minimumReleaseAgeBehaviour to handle Renovate 42.0.0 changes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
 	"prCreation": "immediate",
 	"rebaseWhen": "never",
 	"minimumReleaseAge": "3 days",
+	"minimumReleaseAgeBehaviour": "timestamp-optional",
 	"packageRules": [
 		{
 			"description": "Block automerge for deprecated packages",


### PR DESCRIPTION
## 📝 Commits

- fix: add minimumReleaseAgeBehaviour to handle Renovate 42.0.0 changes