### PR TITLE
fix: remove invalid matchDeprecated from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,5 @@
 	"prCreation": "immediate",
 	"rebaseWhen": "never",
 	"minimumReleaseAge": "3 days",
-	"minimumReleaseAgeBehaviour": "timestamp-optional",
-	"packageRules": [
-		{
-			"description": "Block automerge for deprecated packages",
-			"matchDeprecated": true,
-			"automerge": false
-		}
-	]
+	"minimumReleaseAgeBehaviour": "timestamp-optional"
 }


### PR DESCRIPTION
## 📝 Commits

- fix: remove invalid matchDeprecated from Renovate config