### PR TITLE
chore(deps): update npm version to 11.12.1 across workflows

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -83,9 +83,9 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install npm 11.6.4
+      - name: Install npm 11.12.1
         shell: bash
-        run: npm install -g npm@11.6.4
+        run: npm install -g npm@11.12.1
 
       - name: Install Dependencies
         run: npm ci
@@ -113,9 +113,9 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install npm 11.6.4
+      - name: Install npm 11.12.1
         shell: bash
-        run: npm install -g npm@11.6.4
+        run: npm install -g npm@11.12.1
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -59,8 +59,8 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install npm 11.6.4
-        run: npm install -g npm@11.6.4
+      - name: Install npm 11.12.1
+        run: npm install -g npm@11.12.1
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -224,9 +224,9 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install npm 11.6.4 (non-release builds)
+      - name: Install npm 11.12.1 (non-release builds)
         if: needs.extract-version.outputs.is-release == 'false'
-        run: npm install -g npm@11.6.4
+        run: npm install -g npm@11.12.1
 
       - name: Install dependencies (non-release builds)
         if: needs.extract-version.outputs.is-release == 'false'

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,9 +50,9 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install npm 11.6.4
+      - name: Install npm 11.12.1
         shell: bash
-        run: npm install -g npm@11.6.4
+        run: npm install -g npm@11.12.1
 
       - name: Install Dependencies
         run: npm ci
@@ -134,15 +134,15 @@ jobs:
           subject-path: ${{ env.TARBALL }}
           sbom-path: sbom.json
 
-      - name: Verify npm >= 11.6.4 for Trusted Publishers
+      - name: Verify npm >= 11.12.1 for Trusted Publishers
         run: |
           CURRENT_NPM=$(npm --version)
           echo "Current npm version: $CURRENT_NPM"
-          if [ "$(printf '%s\n' "11.6.4" "$CURRENT_NPM" | sort -V | head -n1)" = "11.6.4" ]; then
-            echo "✓ npm version $CURRENT_NPM is sufficient (>= 11.6.4)"
+          if [ "$(printf '%s\n' "11.12.1" "$CURRENT_NPM" | sort -V | head -n1)" = "11.12.1" ]; then
+            echo "✓ npm version $CURRENT_NPM is sufficient (>= 11.12.1)"
           else
             echo "❌ Error: npm version $CURRENT_NPM is too old"
-            echo "npm >= 11.6.4 is required for Trusted Publishers"
+            echo "npm >= 11.12.1 is required for Trusted Publishers"
             echo "Update Node.js version in workflow or manually install newer npm"
             exit 1
           fi
@@ -150,7 +150,7 @@ jobs:
       - name: Publish to NPM with provenance (Trusted Publishers)
         run: npm publish --provenance --access public
         # Note: No NODE_AUTH_TOKEN needed - npm uses OIDC authentication automatically
-        # Requires: id-token: write permission and npm >= 11.6.4
+        # Requires: id-token: write permission and npm >= 11.12.1
 
       - name: Upload dist/ artifact for Docker build
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/security-main.yml
+++ b/.github/workflows/security-main.yml
@@ -80,8 +80,8 @@ jobs:
           node-version: '24'
 
       # npm must be newer than 11.5.1 for Node 24 compatibility
-      - name: Install npm 11.6.4
-        run: npm install -g npm@11.6.4
+      - name: Install npm 11.12.1
+        run: npm install -g npm@11.12.1
 
       - name: Install dependencies
         run: npm ci
@@ -120,8 +120,8 @@ jobs:
           node-version: '24'
 
       # npm must be newer than 11.5.1 for Node 24 compatibility
-      - name: Install npm 11.6.4
-        run: npm install -g npm@11.6.4
+      - name: Install npm 11.12.1
+        run: npm install -g npm@11.12.1
 
       - name: Install dependencies
         run: npm ci
@@ -209,8 +209,8 @@ jobs:
           node-version: '24'
 
       # npm must be newer than 11.5.1 for Node 24 compatibility
-      - name: Install npm 11.6.4
-        run: npm install -g npm@11.6.4
+      - name: Install npm 11.12.1
+        run: npm install -g npm@11.12.1
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/security-pr.yml
+++ b/.github/workflows/security-pr.yml
@@ -72,8 +72,8 @@ jobs:
           node-version: '24'
 
       # npm must be newer than 11.5.1 for Node 24 compatibility
-      - name: Install npm 11.6.4
-        run: npm install -g npm@11.6.4
+      - name: Install npm 11.12.1
+        run: npm install -g npm@11.12.1
 
       - name: Install dependencies
         run: npm ci
@@ -108,8 +108,8 @@ jobs:
           node-version: '24'
 
       # npm must be newer than 11.5.1 for Node 24 compatibility
-      - name: Install npm 11.6.4
-        run: npm install -g npm@11.6.4
+      - name: Install npm 11.12.1
+        run: npm install -g npm@11.12.1
 
       - name: Install dependencies
         run: npm ci
@@ -149,8 +149,8 @@ jobs:
           node-version: '24'
 
       # npm must be newer than 11.5.1 for Node 24 compatibility
-      - name: Install npm 11.6.4
-        run: npm install -g npm@11.6.4
+      - name: Install npm 11.12.1
+        run: npm install -g npm@11.12.1
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,9 +82,9 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install npm 11.6.4
+      - name: Install npm 11.12.1
         shell: bash
-        run: npm install -g npm@11.6.4
+        run: npm install -g npm@11.12.1
 
       - name: Install Dependencies
         run: npm ci
@@ -117,9 +117,9 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install npm 11.6.4
+      - name: Install npm 11.12.1
         shell: bash
-        run: npm install -g npm@11.6.4
+        run: npm install -g npm@11.12.1
 
       - name: Install Dependencies
         run: npm ci --ignore-scripts


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Summary
- Bumps the npm version installed in CI from 11.6.4 to 11.12.1 across GitHub Actions workflows.
- Updates the npm version check/messaging used for Trusted Publishers to require npm >= 11.12.1.
- Keeps workflow behavior unchanged otherwise (only version numbers and step labels/comments updated).

Files changed
- .github/workflows/fuzz.yml
- .github/workflows/prepare-release.yml
- .github/workflows/publish-docker.yml
- .github/workflows/publish-npm.yml
  - also updates the verification logic and messages to check for >= 11.12.1
- .github/workflows/security-main.yml
- .github/workflows/security-pr.yml
- .github/workflows/test.yml

What changed (functional impact)
- CI job steps that previously installed npm@11.6.4 now install npm@11.12.1.
- The Trusted Publishers publish job now verifies that the installed npm version is at least 11.12.1 (and updates log/output text accordingly).
- Step names and comments referencing the old version were updated to reflect 11.12.1.

Why
- Keep GitHub Actions workflows using a newer npm release (11.12.1), and ensure the publish job enforces that minimum version.
<!-- kody-pr-summary:end -->