### PR TITLE
Update Docker publish workflow secrets

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -312,8 +312,8 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.DOCKER_PUBLISH_LATEST_WEBHOOK }}
           IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
-          CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+          CLIENT_ID: ${{ secrets.GANDER_TOOLS__CF_ACCESS_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.GANDER_TOOLS__CF_ACCESS_CLIENT_SECRET }}
         run: |
           if [ -z "$WEBHOOK_URL" ]; then
             echo "::warning::DOCKER_PUBLISH_LATEST_WEBHOOK secret not set, skipping webhook"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Summary
- Updated the GitHub Actions Docker publish workflow to use new secret names for the Cloudflare Access credentials.

What changed
- In .github/workflows/publish-docker.yml the environment variables for CLIENT_ID and CLIENT_SECRET were switched from:
  - CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET
  to:
  - GANDER_TOOLS__CF_ACCESS_CLIENT_ID / GANDER_TOOLS__CF_ACCESS_CLIENT_SECRET

Functional impact
- The publish-docker workflow will now read Cloudflare Access credentials from the namespaced secrets GANDER_TOOLS__CF_ACCESS_CLIENT_ID and GANDER_TOOLS__CF_ACCESS_CLIENT_SECRET.
- If those secrets are not present, the workflow will not receive the credentials (the webhook steps that rely on them will be affected).

Notes / Action required
- Ensure the repository (or organization) secrets have been renamed/added to match GANDER_TOOLS__CF_ACCESS_CLIENT_ID and GANDER_TOOLS__CF_ACCESS_CLIENT_SECRET so the workflow can authenticate as before.
<!-- kody-pr-summary:end -->