### PR TITLE
Add SafeSkill security badge (60/100 — Use with Caution)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Fuzzing](https://img.shields.io/github/actions/workflow/status/gander-tools/osm-tagging-schema-mcp/fuzz.yml?branch=master&label=fuzzing&logo=github-actions)](https://github.com/gander-tools/osm-tagging-schema-mcp/actions/workflows/fuzz.yml)
 [![Release](https://img.shields.io/github/actions/workflow/status/gander-tools/osm-tagging-schema-mcp/publish-npm.yml?branch=master&label=release&logo=github-actions)](https://github.com/gander-tools/osm-tagging-schema-mcp/actions/workflows/publish-npm.yml)
 [![Docker](https://img.shields.io/github/actions/workflow/status/gander-tools/osm-tagging-schema-mcp/publish-docker.yml?branch=master&label=docker&logo=docker)](https://github.com/gander-tools/osm-tagging-schema-mcp/actions/workflows/publish-docker.yml)
+[![SafeSkill 60/100](https://img.shields.io/badge/SafeSkill-60%2F100_Use%20with%20Caution-orange)](https://safeskill.dev/scan/gander-tools-osm-tagging-schema-mcp)
 
 <!-- Package Information -->
 [![npm downloads](https://img.shields.io/npm/dm/@gander-tools/osm-tagging-schema-mcp?logo=npm)](https://www.npmjs.com/package/@gander-tools/osm-tagging-schema-mcp)


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Summary
- Adds a SafeSkill security badge to the repository README that shows the latest SafeSkill scan score (60/100 — "Use with Caution") and links to the full report.

What changed
- File modified: README.md
- Change: inserted a new shields.io badge right after the existing Docker badge:
  - Badge text: "SafeSkill 60/100_Use with Caution" (URL-encoded for shields.io)
  - Target link: https://safeskill.dev/scan/gander-tools-osm-tagging-schema-mcp

Purpose and impact
- This is a documentation-only change (no source code, tests, or behavior modified).
- Provides immediate, visible disclosure of the SafeSkill scan score on the project homepage and a direct link to the full security report, improving transparency about the repository's security posture.
- No runtime or package behavior is affected by this change.

Notes
- The badge is generated via shields.io and simply links to the SafeSkill report; future updates to the SafeSkill scan should be reflected by updating the badge text or linking to a refreshed report if necessary.
<!-- kody-pr-summary:end -->